### PR TITLE
Update pagination to editable current page

### DIFF
--- a/client/src/components/Pagination/Pagination.jsx
+++ b/client/src/components/Pagination/Pagination.jsx
@@ -1,49 +1,84 @@
 import "./Pagination.css";
+import { useState, useEffect } from "react";
+
 export default function Pagination({ currentPage, totalPages, onPageChange }) {
-  // normalize totalPages to an integer >= 0
   const safeTotal = Number.isFinite(totalPages)
     ? Math.max(0, Math.floor(totalPages))
     : 0;
 
-  const pagesToShow =
-    safeTotal > 3 ? [1, 2, 3] : [...Array(safeTotal)].map((_, i) => i + 1);
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState(currentPage);
+
+  // Sync internal state when prop changes
+  useEffect(() => {
+    setInputValue(currentPage);
+  }, [currentPage]);
+
+  if (safeTotal === 0) return null;
+
+  const submitPage = () => {
+    let page = parseInt(inputValue, 10);
+
+    if (isNaN(page)) {
+      setInputValue(currentPage);
+      setIsEditing(false);
+      return;
+    }
+
+    // Clamp the value between 1 and safeTotal
+    const validatedPage = Math.min(Math.max(page, 1), safeTotal);
+    onPageChange(validatedPage);
+    setIsEditing(false);
+  };
 
   return (
     <div className="pagination">
       <button
         onClick={() => onPageChange(Math.max(currentPage - 1, 1))}
-        disabled={currentPage === 1 || safeTotal === 0}
+        disabled={currentPage === 1}
         className="pagination-btn"
       >
-        ← Prev
+        Prev
       </button>
 
       <div className="page-numbers">
-        {pagesToShow.map((page) => (
+        {isEditing ? (
+          <input
+            className="page-number-btn active"
+            type="number"
+            autoFocus
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            // Use onKeyDown to trigger submit
+            onKeyDown={(e) => {
+              if (e.key === "Enter") submitPage();
+              if (e.key === "Escape") {
+                setInputValue(currentPage);
+                setIsEditing(false);
+              }
+            }}
+            // If they click away, save the page or cancel
+            onBlur={submitPage}
+          />
+        ) : (
           <button
-            key={page}
-            onClick={() => onPageChange(page)}
-            className={`page-number-btn ${currentPage === page ? "active" : ""}`}
+            className="page-number-btn active"
+            onClick={() => setIsEditing(true)}
           >
-            {page}
+            {currentPage}
           </button>
-        ))}
-
-        {safeTotal > 3 && (
-          <span className="ellipsis" aria-hidden="true">
-            ...
-          </span>
         )}
       </div>
 
       <button
-        // always go to next page (clamped to safeTotal)
         onClick={() => onPageChange(Math.min(currentPage + 1, safeTotal))}
-        disabled={currentPage >= safeTotal || safeTotal === 0}
+        disabled={currentPage === safeTotal}
         className="pagination-btn"
       >
-        Next →
+        Next
       </button>
+
+      <span className="ellipsis">out of {safeTotal}</span>
     </div>
   );
 }

--- a/client/src/components/Pagination/Pagination.jsx
+++ b/client/src/components/Pagination/Pagination.jsx
@@ -1,5 +1,5 @@
 import "./Pagination.css";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 
 export default function Pagination({ currentPage, totalPages, onPageChange }) {
   const safeTotal = Number.isFinite(totalPages)
@@ -9,17 +9,24 @@ export default function Pagination({ currentPage, totalPages, onPageChange }) {
   const [isEditing, setIsEditing] = useState(false);
   const [inputValue, setInputValue] = useState(currentPage);
 
-  // Sync internal state when prop changes, but avoid overwriting while editing
-  useEffect(() => {
+  // Track the previous prop to detect changes during render
+  const [prevPage, setPrevPage] = useState(currentPage);
+
+  /**
+   * FIX: Synchronizing state during render.
+   * This replaces useEffect and avoids "cascading renders."
+   * React allows calling a setter during render if it's wrapped in a condition.
+   */
+  if (currentPage !== prevPage) {
+    setPrevPage(currentPage);
     if (!isEditing) {
       setInputValue(currentPage);
     }
-  }, [currentPage, isEditing]);
-
+  }
   if (safeTotal === 0) return null;
 
   const submitPage = () => {
-    let page = parseInt(inputValue, 10);
+    const page = parseInt(inputValue, 10);
 
     if (isNaN(page)) {
       setInputValue(currentPage);
@@ -34,11 +41,16 @@ export default function Pagination({ currentPage, totalPages, onPageChange }) {
   };
 
   return (
-    <div className="pagination">
+    <div
+      className="pagination"
+      role="navigation"
+      aria-label="Pagination Navigation"
+    >
       <button
         onClick={() => onPageChange(Math.max(currentPage - 1, 1))}
         disabled={currentPage === 1}
         className="pagination-btn"
+        aria-label="Go to previous page"
       >
         Prev
       </button>
@@ -46,26 +58,32 @@ export default function Pagination({ currentPage, totalPages, onPageChange }) {
       <div className="page-numbers">
         {isEditing ? (
           <input
-            className="page-number-btn active"
+            aria-label="Page number input"
+            className="page-number-input"
             type="number"
+            min="1"
+            max={safeTotal}
             autoFocus
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
-            // Use onKeyDown to trigger submit
             onKeyDown={(e) => {
-              if (e.key === "Enter") submitPage();
+              if (e.key === "Enter") {
+                submitPage();
+              }
               if (e.key === "Escape") {
                 setInputValue(currentPage);
                 setIsEditing(false);
               }
             }}
-            // If they click away, save the page or cancel
-            onBlur={submitPage}
+            onBlur={() => {
+              if (isEditing) submitPage();
+            }}
           />
         ) : (
           <button
-            className="page-number-btn active"
+            className="page-display-trigger"
             onClick={() => setIsEditing(true)}
+            title="Click to edit page number"
           >
             {currentPage}
           </button>
@@ -76,11 +94,12 @@ export default function Pagination({ currentPage, totalPages, onPageChange }) {
         onClick={() => onPageChange(Math.min(currentPage + 1, safeTotal))}
         disabled={currentPage === safeTotal}
         className="pagination-btn"
+        aria-label="Go to next page"
       >
         Next
       </button>
 
-      <span className="ellipsis">out of {safeTotal}</span>
+      <span className="page-total">out of {safeTotal}</span>
     </div>
   );
 }

--- a/client/src/components/Pagination/Pagination.jsx
+++ b/client/src/components/Pagination/Pagination.jsx
@@ -9,10 +9,12 @@ export default function Pagination({ currentPage, totalPages, onPageChange }) {
   const [isEditing, setIsEditing] = useState(false);
   const [inputValue, setInputValue] = useState(currentPage);
 
-  // Sync internal state when prop changes
+  // Sync internal state when prop changes, but avoid overwriting while editing
   useEffect(() => {
-    setInputValue(currentPage);
-  }, [currentPage]);
+    if (!isEditing) {
+      setInputValue(currentPage);
+    }
+  }, [currentPage, isEditing]);
 
   if (safeTotal === 0) return null;
 


### PR DESCRIPTION
Allow users to edit the current page number directly by clicking it and entering a value. Input is validated and clamped within valid page range.