### PR TITLE
Fetch-jobs-fix

### DIFF
--- a/client/src/components/DropdownSort/DropdownSort.jsx
+++ b/client/src/components/DropdownSort/DropdownSort.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from "react";
-import { Handshake, Bus, Clock } from "lucide-react";
+import { Handshake, Bus, Calendar } from "lucide-react";
 import useOutsideClick from "../../hooks/useOutsideClick";
 import "./DropdownSort.css";
 
@@ -70,7 +70,7 @@ export default function DropdownSort({ selectedSort, setSelectedSort }) {
             <Bus size={16} />
           </span>
           <span className="job-icon">
-            <Clock size={16} />
+            <Calendar size={16} />
           </span>
           <span>Custom sort</span>
         </div>

--- a/client/src/components/JobCard/JobCard.jsx
+++ b/client/src/components/JobCard/JobCard.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import {
   Bus,
   Briefcase,
-  Clock,
+  Calendar,
   GraduationCap,
   MapPin,
   Monitor,
@@ -169,7 +169,7 @@ export default function JobCard({ job, onApplyClick, isInFavorites }) {
                   const formatted = `${dd} ${mm} ${yyyy}`;
                   return (
                     <div className="job-commute-info">
-                      <Clock className="job-icon" />
+                      <Calendar className="job-icon" />
                       <span className="job-commute">{formatted}</span>
                       <span className="job-tag-separator">|</span>
                     </div>

--- a/server/src/services/persistJobSearch.js
+++ b/server/src/services/persistJobSearch.js
@@ -16,6 +16,7 @@ export default async function persistJobSearch(
   if (!connectionError) {
     const jobsToInsert = [];
     const searchStringJobsToInsert = [];
+    const idSet = new Set();
 
     await connectedClient.query("BEGIN");
     try {
@@ -47,16 +48,13 @@ export default async function persistJobSearch(
             .some(([, value]) => value === null) &&
           new Date(job.date_posted) >= oneMonthAgo
         ) {
-          try {
+          if (!idSet.has(job.id)) {
+            idSet.add(job.id);
             jobsToInsert.push(job);
-
-            // Collect search_strings_jobs relationships
             searchStringJobsToInsert.push({
               search_string,
               jobId: job.id,
             });
-          } catch (jobErr) {
-            logError(`Error processing job ${job.id}: ${jobErr}`);
           }
         }
       }

--- a/server/src/util/normalizeEmploymentType.js
+++ b/server/src/util/normalizeEmploymentType.js
@@ -1,0 +1,16 @@
+export default function normalizeEmploymentType(typeList) {
+  let result = null;
+  if (Array.isArray(typeList) && typeList.length > 0) {
+    const type = typeList[0];
+    if (typeof type === "string" && type.length > 0) {
+      if (type === "Intern") {
+        result = "Internship";
+      } else {
+        result = (
+          type.charAt(0).toUpperCase() + type.slice(1).toLowerCase()
+        ).replace("_", "-");
+      }
+    }
+  }
+  return result;
+}

--- a/server/src/util/normalizeEmploymentType.js
+++ b/server/src/util/normalizeEmploymentType.js
@@ -8,7 +8,7 @@ export default function normalizeEmploymentType(typeList) {
       } else {
         result = (
           type.charAt(0).toUpperCase() + type.slice(1).toLowerCase()
-        ).replace("_", "-");
+        ).replaceAll("_", "-");
       }
     }
   }

--- a/server/src/util/processRapidAPIjob.js
+++ b/server/src/util/processRapidAPIjob.js
@@ -2,6 +2,7 @@ import normalizeDescription from "./normalizeDescription.js";
 import validateJob from "./validateJob.js";
 import normalizeUrl from "./normalizeUrl.js";
 import checkExperienceLevel from "./checkExperienceLevel.js";
+import normalizeEmploymentType from "./normalizeEmploymentType.js";
 
 export default function processRapidAPIjob(job) {
   const {
@@ -48,25 +49,12 @@ export default function processRapidAPIjob(job) {
 
   const url = normalizeUrl(url1) || normalizeUrl(url2);
 
-  function normalizeEmploymentType(type) {
-    if (type === "Intern") {
-      return "Internship";
-    }
-    return type;
-  }
-
   const processedJob = {
     id: url,
     url,
     title,
     date_posted,
-    employment_type:
-      Array.isArray(employment_type) && employment_type.length > 0
-        ? normalizeEmploymentType(
-            (employment_type[0].charAt(0).toUpperCase() + employment_type,
-            [0].slice(1).toLowerCase()).replace("_", "-"),
-          )
-        : null,
+    employment_type: normalizeEmploymentType(employment_type),
     work_mode: remote_derived === true ? "Remote" : "On-site",
     display_location:
       Array.isArray(locations_derived) && locations_derived.length > 0


### PR DESCRIPTION
This PR introduces a shared normalizeEmploymentType utility and wires it into the RapidAPI job normalization pipeline to standardize employment_type values before validation/persistence.

Changes:

    Added server/src/util/normalizeEmploymentType.js to encapsulate employment type normalization logic.
    Updated server/src/util/processRapidAPIjob.js to use the new utility instead of an inline implementation.
    Changed persistJobSearch behavior (deduping jobs via idSet).
