### PR TITLE
fix: strip ?refId= from job URLs for stable job id and deduplication

### DIFF
--- a/server/src/util/normalizeUrl.js
+++ b/server/src/util/normalizeUrl.js
@@ -7,3 +7,16 @@ export default function normalizeUrl(url) {
   if (!url) return "";
   return url.startsWith("http") ? url : `https://${url}`;
 }
+
+/**
+ * Strips everything from ?refId= onwards so the same job role is not treated as
+ * multiple jobs when optional query params (refId, trackingId, position, pageNum) differ.
+ * @param {string} url - Job URL (e.g. LinkedIn)
+ * @returns {string} - URL without refId and following query params
+ */
+export function stripRefIdFromUrl(url) {
+  if (!url || typeof url !== "string") return url || "";
+  const i = url.toLowerCase().indexOf("?refid=");
+  if (i === -1) return url;
+  return url.slice(0, i);
+}

--- a/server/src/util/processRapidAPIjob.js
+++ b/server/src/util/processRapidAPIjob.js
@@ -48,9 +48,7 @@ export default function processRapidAPIjob(job) {
       normalizedSeniority = seniority;
   }
 
-  const url = stripRefIdFromUrl(
-    normalizeUrl(url1) || normalizeUrl(url2),
-  );
+  const url = stripRefIdFromUrl(normalizeUrl(url1) || normalizeUrl(url2));
   const normalized_description =
     normalizeDescription(title) + normalizeDescription(description_text);
 

--- a/server/src/util/processRapidAPIjob.js
+++ b/server/src/util/processRapidAPIjob.js
@@ -1,6 +1,6 @@
 import normalizeDescription from "./normalizeDescription.js";
 import validateJob from "./validateJob.js";
-import normalizeUrl from "./normalizeUrl.js";
+import normalizeUrl, { stripRefIdFromUrl } from "./normalizeUrl.js";
 import checkExperienceLevel from "./checkExperienceLevel.js";
 import normalizeEmploymentType from "./normalizeEmploymentType.js";
 import detectLanguage from "./detectLanguage.js";
@@ -48,7 +48,9 @@ export default function processRapidAPIjob(job) {
       normalizedSeniority = seniority;
   }
 
-  const url = normalizeUrl(url1) || normalizeUrl(url2);
+  const url = stripRefIdFromUrl(
+    normalizeUrl(url1) || normalizeUrl(url2),
+  );
   const normalized_description =
     normalizeDescription(title) + normalizeDescription(description_text);
 

--- a/server/src/util/processScraperJob.js
+++ b/server/src/util/processScraperJob.js
@@ -1,6 +1,6 @@
 import normalizeDescription from "./normalizeDescription.js";
 import validateJob from "./validateJob.js";
-import normalizeUrl from "./normalizeUrl.js";
+import normalizeUrl, { stripRefIdFromUrl } from "./normalizeUrl.js";
 import checkExperienceLevel from "./checkExperienceLevel.js";
 import detectLanguage from "./detectLanguage.js";
 
@@ -30,7 +30,9 @@ export default function processScraperJob(job) {
       normalizedSeniority = seniorityLevel;
   }
 
-  const url = normalizeUrl(url1) || normalizeUrl(url2);
+  const url = stripRefIdFromUrl(
+    normalizeUrl(url1) || normalizeUrl(url2),
+  );
   const normalized_description =
     normalizeDescription(title) + normalizeDescription(descriptionText);
 

--- a/server/src/util/processScraperJob.js
+++ b/server/src/util/processScraperJob.js
@@ -30,9 +30,7 @@ export default function processScraperJob(job) {
       normalizedSeniority = seniorityLevel;
   }
 
-  const url = stripRefIdFromUrl(
-    normalizeUrl(url1) || normalizeUrl(url2),
-  );
+  const url = stripRefIdFromUrl(normalizeUrl(url1) || normalizeUrl(url2));
   const normalized_description =
     normalizeDescription(title) + normalizeDescription(descriptionText);
 


### PR DESCRIPTION
Added stripRefIdFromUrl(url) in server/src/util/normalizeUrl.js. The function removes everything from ?refId= (or ?refid=, case-insensitive) to the end of the URL.