### PR TITLE
D bskills saving simplification 12

### DIFF
--- a/client/src/components/SkillsSettings/AIPopup.jsx
+++ b/client/src/components/SkillsSettings/AIPopup.jsx
@@ -4,7 +4,7 @@ import { gif } from "../../assets/index.js";
 import AlertMessage from "../AlertMessage/AlertMessage";
 import { DELAYED_CLEAR_INTERVAL } from "../../util/constants";
 import { UseUser } from "../../context/UserContext";
-import regexEndNormalizeSkill from "../../util/regexEndNormalizeSkill.js";
+import { convertName2Obj } from "../../util/skillsConversion.js";
 import cleanUpText from "../../util/cleanUpText.js";
 
 export default function AIPopup({ setShowAll, onClose, setAiSkills }) {
@@ -36,7 +36,7 @@ export default function AIPopup({ setShowAll, onClose, setAiSkills }) {
         );
 
         const filtered = result.skills
-          .map((skill) => regexEndNormalizeSkill(cleanUpText(skill)))
+          .map((skill) => convertName2Obj(cleanUpText(skill)))
           .filter((s) => !existingSkills.has(s.normalizedSkill))
           .sort((a, b) => a.normalizedSkill.localeCompare(b.normalizedSkill));
 

--- a/client/src/components/SkillsSettings/SkillsSettings.jsx
+++ b/client/src/components/SkillsSettings/SkillsSettings.jsx
@@ -10,7 +10,10 @@ import AIPopup from "./AIPopup";
 // Hook & Utility imports
 import useFetch from "../../hooks/useFetch";
 import cleanUpText from "../../util/cleanUpText";
-import regexEndNormalizeSkill from "../../util/regexEndNormalizeSkill";
+import {
+  convertName2Obj,
+  convertObjects2Names,
+} from "../../util/skillsConversion";
 import validateSkillInput from "../../util/skillValidation";
 import { gif } from "../../assets/index.js";
 import { DELAYED_CLEAR_INTERVAL } from "../../util/constants";
@@ -74,7 +77,7 @@ export default function SkillsSettings() {
   }
 
   async function changeSkillsHelper(skills) {
-    const skillNames = skills.map((s) => s.skill);
+    const skillNames = convertObjects2Names(skills);
 
     performFetch({
       method: "POST",
@@ -99,7 +102,7 @@ export default function SkillsSettings() {
     }
 
     const prevSkills = Array.isArray(user?.skills) ? user.skills : [];
-    const newSkillObj = regexEndNormalizeSkill(newSkill);
+    const newSkillObj = convertName2Obj(newSkill);
     const combined = [...prevSkills, newSkillObj].sort((a, b) =>
       String(a?.normalizedSkill ?? "").localeCompare(
         String(b?.normalizedSkill ?? ""),
@@ -140,7 +143,7 @@ export default function SkillsSettings() {
       if (validationError) {
         failedSkills.push(newSkill);
       } else {
-        combined.push(regexEndNormalizeSkill(newSkill));
+        combined.push(convertName2Obj(newSkill));
         newAiSkills = newAiSkills.filter(
           (aiSkill) => aiSkill.normalizedSkill !== aiSkills[i]?.normalizedSkill,
         );

--- a/client/src/context/UserContext.jsx
+++ b/client/src/context/UserContext.jsx
@@ -6,7 +6,7 @@ import {
   useEffect,
 } from "react";
 import { defaultUser } from "../data/defaultUser";
-import fixUserSkills from "../util/fixUserSkills";
+import { convertNames2Objects } from "../util/skillsConversion";
 import useFetch from "../hooks/useFetch";
 import userReducer from "../reducers/userReducer";
 
@@ -25,7 +25,7 @@ function UserContextProvider({ children }) {
   // -------------------- GET CURRENT USER --------------------
   function handleFetchMeResults(data) {
     if (data.user) {
-      const normalizedSkills = fixUserSkills(data.user.skills);
+      const normalizedSkills = convertNames2Objects(data.user.skills);
       const favoriteJobs = Array.isArray(data.user.favorites)
         ? data.user.favorites.map((job) => ({
             id: job.id,

--- a/client/src/context/UserContext.jsx
+++ b/client/src/context/UserContext.jsx
@@ -25,7 +25,6 @@ function UserContextProvider({ children }) {
   // -------------------- GET CURRENT USER --------------------
   function handleFetchMeResults(data) {
     if (data.user) {
-      const normalizedSkills = convertNames2Objects(data.user.skills);
       const favoriteJobs = Array.isArray(data.user.favorites)
         ? data.user.favorites.map((job) => ({
             id: job.id,
@@ -49,7 +48,7 @@ function UserContextProvider({ children }) {
         type: "LOGIN",
         payload: {
           ...data.user,
-          skills: normalizedSkills,
+          skills: convertNames2Objects(data.user.skills),
           favorites: favoriteJobs,
         },
       });

--- a/client/src/data/defaultUser.js
+++ b/client/src/data/defaultUser.js
@@ -1,5 +1,5 @@
 import { images } from "../assets";
-import regexEndNormalizeSkill from "../util/regexEndNormalizeSkill";
+import { convertNames2Objects } from "../util/skillsConversion";
 
 export function formatAddress(user) {
   const streetAddress = [
@@ -50,8 +50,8 @@ export const defaultUser = {
   house_number: 123,
   city: "Amsterdam",
   country: "Netherlands",
-  skills: defaultSkillNames
-    .map((skill) => regexEndNormalizeSkill(skill))
-    .sort((a, b) => a.normalizedSkill.localeCompare(b.normalizedSkill)),
+  skills: convertNames2Objects(defaultSkillNames).sort((a, b) =>
+    a.normalizedSkill.localeCompare(b.normalizedSkill),
+  ),
   favorites: [],
 };

--- a/client/src/pages/LoginForm.jsx
+++ b/client/src/pages/LoginForm.jsx
@@ -23,7 +23,6 @@ export default function LoginForm({
   }
 
   function handleLoginResults(data) {
-    const normalizedSkills = convertNames2Objects(data.user.skills);
     const favoriteJobs = Array.isArray(data.user.favorites)
       ? data.user.favorites.map((job) => ({
           id: job.id,
@@ -48,7 +47,7 @@ export default function LoginForm({
       type: "LOGIN",
       payload: {
         ...data.user,
-        skills: normalizedSkills,
+        skills: convertNames2Objects(data.user.skills),
         favorites: favoriteJobs,
       },
     });

--- a/client/src/pages/LoginForm.jsx
+++ b/client/src/pages/LoginForm.jsx
@@ -4,7 +4,7 @@ import { UseUser } from "../context/UserContext";
 import AlertMessage from "../components/AlertMessage/AlertMessage";
 import { gif } from "../assets";
 import useFetch from "../hooks/useFetch";
-import fixUserSkills from "../util/fixUserSkills";
+import { convertNames2Objects } from "../util/skillsConversion";
 import DonationPopup from "../components/DonationPopup/DonationPopup";
 
 export default function LoginForm({
@@ -23,7 +23,7 @@ export default function LoginForm({
   }
 
   function handleLoginResults(data) {
-    const normalizedSkills = fixUserSkills(data.user.skills);
+    const normalizedSkills = convertNames2Objects(data.user.skills);
     const favoriteJobs = Array.isArray(data.user.favorites)
       ? data.user.favorites.map((job) => ({
           id: job.id,

--- a/client/src/pages/Profile/Profile.jsx
+++ b/client/src/pages/Profile/Profile.jsx
@@ -8,7 +8,7 @@ import validateAddressTextInputs from "../../util/addressTextsValidation";
 import validateHouseNoInput from "../../util/addressHouseNoValidation";
 import { UseUser } from "../../context/UserContext";
 import useFetch from "../../hooks/useFetch";
-import fixUserSkills from "../../util/fixUserSkills";
+import { convertNames2Objects } from "../../util/skillsConversion";
 import AvatarUploader from "../../components/AvatarUploader/AvatarUploader";
 import DeleteProfilePopup from "../../components/DeleteProfilePopup/DeleteProfilePopup";
 import { DELAYED_CLEAR_INTERVAL } from "../../util/constants";
@@ -46,7 +46,7 @@ export default function Profile() {
       type: "UPDATE_USER",
       payload: {
         ...data.user,
-        skills: fixUserSkills(data.user.skills),
+        skills: convertNames2Objects(data.user.skills),
       },
     });
     setAlert({ type: "success", message: "Profile updated successfully!" });

--- a/client/src/pages/SignupForm.jsx
+++ b/client/src/pages/SignupForm.jsx
@@ -18,7 +18,10 @@ import {
 import AlertMessage from "../components/AlertMessage/AlertMessage";
 import { gif } from "../assets";
 import useFetch from "../hooks/useFetch";
-import fixUserSkills from "../util/fixUserSkills";
+import {
+  convertNames2Objects,
+  convertObjects2Names,
+} from "../util/skillsConversion";
 import { defaultUser } from "../data/defaultUser";
 
 function renderRuleItem(condition, text) {
@@ -53,7 +56,7 @@ export default function SignupForm({ setSignupSuccessPopup, switchToLogin }) {
   }
 
   function handleSignupResults(data) {
-    const normalizedSkills = fixUserSkills(data.user.skills);
+    const normalizedSkills = convertNames2Objects(data.user.skills);
     dispatch({
       type: "REGISTER",
       payload: {
@@ -117,7 +120,7 @@ export default function SignupForm({ setSignupSuccessPopup, switchToLogin }) {
       body: JSON.stringify({
         user: {
           ...defaultUser,
-          skills: defaultUser.skills.map((s) => s.skill),
+          skills: convertObjects2Names(defaultUser.skills),
           first_name: signupData.first_name,
           last_name: signupData.last_name,
           email: signupData.email,

--- a/client/src/pages/SignupForm.jsx
+++ b/client/src/pages/SignupForm.jsx
@@ -56,12 +56,11 @@ export default function SignupForm({ setSignupSuccessPopup, switchToLogin }) {
   }
 
   function handleSignupResults(data) {
-    const normalizedSkills = convertNames2Objects(data.user.skills);
     dispatch({
       type: "REGISTER",
       payload: {
         ...data.user,
-        skills: normalizedSkills,
+        skills: convertNames2Objects(data.user.skills),
         favorites: [],
       },
     });

--- a/client/src/util/fixUserSkills.js
+++ b/client/src/util/fixUserSkills.js
@@ -1,9 +1,0 @@
-import regexEndNormalizeSkill from "./regexEndNormalizeSkill";
-
-export default function fixUserSkills(skills) {
-  let result = [];
-  if (Array.isArray(skills)) {
-    result = skills.map((skill) => regexEndNormalizeSkill(skill));
-  }
-  return result;
-}

--- a/client/src/util/fixUserSkills.js
+++ b/client/src/util/fixUserSkills.js
@@ -1,20 +1,9 @@
 import regexEndNormalizeSkill from "./regexEndNormalizeSkill";
 
 export default function fixUserSkills(skills) {
-  // Accept either an array of skill strings or a comma-separated skills string
-  let arr = [];
+  let result = [];
   if (Array.isArray(skills)) {
-    arr = skills;
-  } else if (typeof skills === "string" && skills.trim() !== "") {
-    arr = skills
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean);
-  } else {
-    return [];
+    result = skills.map((skill) => regexEndNormalizeSkill(skill));
   }
-
-  return arr
-    .map((skill) => regexEndNormalizeSkill(skill))
-    .sort((a, b) => a.normalizedSkill.localeCompare(b.normalizedSkill));
+  return result;
 }

--- a/client/src/util/regexEndNormalizeSkill.js
+++ b/client/src/util/regexEndNormalizeSkill.js
@@ -29,5 +29,5 @@ export default function regexEndNormalizeSkill(skill) {
   let escaped = normalizedSkill;
   escaped = escaped.replace(/[.*+?^${}()|[\]\\#]/g, "\\$&");
   const skillRegex = new RegExp(" " + escaped + " ", "i");
-  return { skill, skillRegex, normalizedSkill };
+  return { skill, normalizedSkill, skillRegex };
 }

--- a/client/src/util/skillsConversion.js
+++ b/client/src/util/skillsConversion.js
@@ -13,14 +13,14 @@
  * @param {string} skill - The raw skill text to escape and normalize.
  *
  * Returns:
- * @returns {{ skill: string, skillRegex: RegExp, normalizedSkill: string }}
+ * @returns {{ skill: string, normalizedSkill: string, skillRegex: RegExp }}
  * - skill: the original input string.
  * - skillRegex: a case-insensitive RegExp that matches the skill as a standalone token
  *   (note: the regex built here uses surrounding spaces when matching).
  * - normalizedSkill: the input with hyphens, slashes and whitespace collapsed to single
  *   spaces (useful for normalization and comparisons).
  */
-export default function regexEndNormalizeSkill(skill) {
+export function convertName2Obj(skill) {
   let normalizedSkill = skill;
   normalizedSkill = normalizedSkill
     .toLowerCase()
@@ -30,4 +30,16 @@ export default function regexEndNormalizeSkill(skill) {
   escaped = escaped.replace(/[.*+?^${}()|[\]\\#]/g, "\\$&");
   const skillRegex = new RegExp(" " + escaped + " ", "i");
   return { skill, normalizedSkill, skillRegex };
+}
+
+export function convertNames2Objects(skills) {
+  let result = [];
+  if (Array.isArray(skills)) {
+    result = skills.map((skill) => convertName2Obj(skill));
+  }
+  return result;
+}
+
+export function convertObjects2Names(skills) {
+  return skills.map((s) => s.skill);
 }

--- a/server/src/controllers/profile.js
+++ b/server/src/controllers/profile.js
@@ -13,7 +13,7 @@ const USER_FULL_INFO_QUERY = `
   LEFT JOIN jobs j ON uf.job_id = j.id
 `;
 
-async function updateUserProfile(user_id, fieldsToUpdate) {
+export default async function updateUserProfile(user_id, fieldsToUpdate) {
   let setParts = [];
   let values = [];
   let i = 1;
@@ -70,9 +70,7 @@ async function updateUserProfile(user_id, fieldsToUpdate) {
       house_number: userDataRow.house_number,
       city: userDataRow.city,
       country: userDataRow.country,
-      skills: userDataRow.skills
-        ? userDataRow.skills.split(",").map((skill) => skill.trim())
-        : [],
+      skills: userDataRow.skills ? userDataRow.skills.split(",") : [],
       favorites: [],
     };
 
@@ -104,5 +102,3 @@ async function updateUserProfile(user_id, fieldsToUpdate) {
     if (endConnection) await endConnection();
   }
 }
-
-export default updateUserProfile;

--- a/server/src/controllers/user.js
+++ b/server/src/controllers/user.js
@@ -319,11 +319,7 @@ export async function getMe(req, res) {
       house_number: userDataRow.house_number,
       city: userDataRow.city,
       country: userDataRow.country,
-      skills: userDataRow.skills
-        ? userDataRow.skills.split(",").map((skill) => skill.trim())
-        : [],
-      favorites: [],
-      number_of_logins: userDataRow.number_of_logins,
+      skills: userDataRow.skills ? userDataRow.skills.split(",") : [],
     };
     rows.forEach((row) => {
       if (row.job_id) {

--- a/server/src/controllers/user.js
+++ b/server/src/controllers/user.js
@@ -200,9 +200,7 @@ export async function loginUser(req, res) {
       house_number: userDataRow.house_number,
       city: userDataRow.city,
       country: userDataRow.country,
-      skills: userDataRow.skills
-        ? userDataRow.skills.split(",").map((skill) => skill.trim())
-        : [],
+      skills: userDataRow.skills ? userDataRow.skills.split(",") : [],
       favorites: [],
       time_to_donate:
         userDataRow.number_of_logins + 1 === 5


### PR DESCRIPTION
## Pull request overview

This pull request refactors the skills handling logic to simplify how skills are converted between string arrays and skill objects. The changes consolidate skills conversion utilities, rename functions for better clarity, and streamline the data transformation pipeline.

**Changes:**
- Consolidated skills conversion logic into `skillsConversion.js` by renaming `regexEndNormalizeSkill` to `convertName2Obj` and adding new helper functions
- Removed the `fixUserSkills.js` utility file as its functionality is now handled by the new conversion functions
- Simplified server-side skill parsing in the login endpoint by removing the `.trim()` operation after splitting