### PR TITLE
update use useAlert in OpenPositions, Profile, auth forms, Skills, Se…

### DIFF
--- a/client/src/components/AvatarUploader/AvatarUploader.jsx
+++ b/client/src/components/AvatarUploader/AvatarUploader.jsx
@@ -3,17 +3,10 @@ import { UseUser } from "../../context/UserContext";
 import "./AvatarUploader.css";
 import useFetch from "../../hooks/useFetch";
 import { gif } from "../../assets";
-import { DELAYED_CLEAR_INTERVAL } from "../../util/constants";
 
-export default function AvatarUploader({ setAlert }) {
+export default function AvatarUploader({ setAlert, delayedClearAlert }) {
   const { user, dispatch } = UseUser();
   const fileInputRef = useRef(null);
-
-  function delayedClearAlert() {
-    setTimeout(() => {
-      setAlert({ type: "", message: "" });
-    }, DELAYED_CLEAR_INTERVAL);
-  }
 
   const { isLoading, error, performFetch } = useFetch(
     "/users/update-avatar",

--- a/client/src/components/SearchInput/SearchInput.jsx
+++ b/client/src/components/SearchInput/SearchInput.jsx
@@ -3,13 +3,13 @@ import { useNavigate } from "react-router-dom";
 import { UseJobs } from "../../context/JobsContext";
 import AlertMessage from "../AlertMessage/AlertMessage";
 import validateJobInput from "../../util/searchValidation";
+import useAlert from "../../hooks/useAlert";
 import "./SearchInput.css";
 import cleanUpText from "../../util/cleanUpText";
 
 export default function SearchInput() {
   const { setSearchString, setAllJobs, performJobFetch } = UseJobs();
-
-  const [alert, setAlert] = useState({ type: "", message: "" });
+  const { alert, setAlert } = useAlert();
   const inputRef = useRef(null);
   const navigate = useNavigate();
 

--- a/client/src/components/SearchInput/SearchInput.jsx
+++ b/client/src/components/SearchInput/SearchInput.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { UseJobs } from "../../context/JobsContext";
 import AlertMessage from "../AlertMessage/AlertMessage";

--- a/client/src/components/SkillsSettings/AIPopup.jsx
+++ b/client/src/components/SkillsSettings/AIPopup.jsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import useFetch from "../../hooks/useFetch";
+import useAlert from "../../hooks/useAlert";
 import { gif } from "../../assets/index.js";
 import AlertMessage from "../AlertMessage/AlertMessage";
-import { DELAYED_CLEAR_INTERVAL } from "../../util/constants";
 import { UseUser } from "../../context/UserContext";
 import validateSkillInput from "../../util/skillValidation";
 import normalizeText from "../../../../shared/normalizeText.js";
@@ -10,17 +10,8 @@ import normalizeText from "../../../../shared/normalizeText.js";
 export default function AIPopup({ setShowAll, onClose, setAiSkills }) {
   const { user } = UseUser();
   const [aiInputText, setAiInputText] = useState("");
-  const [alert, setAlert] = useState({ type: "", message: "" });
+  const { alert, setAlert, clearAlert, delayedClearAlert } = useAlert();
   const isCVRef = useRef(true);
-
-  function handleClearAlert() {
-    setAlert({ type: "", message: "" });
-  }
-  function delayedClearAlert() {
-    setTimeout(() => {
-      handleClearAlert();
-    }, DELAYED_CLEAR_INTERVAL);
-  }
 
   const { isLoading, error, performFetch } = useFetch(
     "/ai/assist-skills",
@@ -81,7 +72,7 @@ export default function AIPopup({ setShowAll, onClose, setAiSkills }) {
   }, [error]);
 
   async function handleGetSkills(isCV) {
-    handleClearAlert();
+    clearAlert();
     isCVRef.current = isCV;
 
     performFetch({

--- a/client/src/components/SkillsSettings/SkillsSettings.jsx
+++ b/client/src/components/SkillsSettings/SkillsSettings.jsx
@@ -9,18 +9,18 @@ import SkillsTipPopup from "../SuccessPopup/SkillsTipPopup";
 import AIPopup from "./AIPopup";
 // Hook & Utility imports
 import useFetch from "../../hooks/useFetch";
+import useAlert from "../../hooks/useAlert";
 import cleanUpText from "../../util/cleanUpText";
 import normalizeText from "../../../../shared/normalizeText";
 import validateSkillInput from "../../util/skillValidation";
 import { gif } from "../../assets/index.js";
-import { DELAYED_CLEAR_INTERVAL } from "../../util/constants";
 // Styles
 import "./SkillsSettings.css";
 
 export default function SkillsSettings() {
   const navigate = useNavigate();
   const skillInputRef = useRef(null);
-  const [alert, setAlert] = useState({ type: "", message: "" });
+  const { alert, setAlert, clearAlert, delayedClearAlert } = useAlert();
   const [showAll, setShowAll] = useState(false);
   const [showTipPopup, setShowTipPopup] = useState(false);
   const maxVisible = 4;
@@ -30,16 +30,6 @@ export default function SkillsSettings() {
   const [showAIPopup, setShowAIPopup] = useState(false);
   const handleSkillsResultsRef = useRef(() => {});
   const [aiSkills, setAiSkills] = useState([]);
-
-  function handleClearAlert() {
-    setAlert({ type: "", message: "" });
-  }
-
-  function delayedClearAlert() {
-    setTimeout(() => {
-      handleClearAlert();
-    }, DELAYED_CLEAR_INTERVAL);
-  }
 
   const {
     isLoading,
@@ -201,7 +191,7 @@ export default function SkillsSettings() {
             onKeyDown={(e) => {
               if (e.key === "Enter") handleInputSkill();
             }}
-            onChange={handleClearAlert}
+            onChange={clearAlert}
           />
 
           <button

--- a/client/src/hooks/useAlert.js
+++ b/client/src/hooks/useAlert.js
@@ -1,0 +1,23 @@
+import { useState, useCallback } from "react";
+import { DELAYED_CLEAR_INTERVAL } from "../util/constants";
+
+/**
+ * Unified alert state and helpers. Use in place of local alert state + handleClearAlert + delayedClearAlert.
+ * @returns {{ alert: { type: string, message: string }, setAlert: function, clearAlert: function, delayedClearAlert: function }}
+ */
+export default function useAlert() {
+  const [alert, setAlert] = useState({ type: "", message: "" });
+
+  const clearAlert = useCallback(() => {
+    setAlert({ type: "", message: "" });
+  }, []);
+
+  const delayedClearAlert = useCallback(() => {
+    const id = setTimeout(() => {
+      setAlert({ type: "", message: "" });
+    }, DELAYED_CLEAR_INTERVAL);
+    return () => clearTimeout(id);
+  }, []);
+
+  return { alert, setAlert, clearAlert, delayedClearAlert };
+}

--- a/client/src/pages/ForgotPassword.jsx
+++ b/client/src/pages/ForgotPassword.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import useFetch from "../hooks/useFetch";
+import useAlert from "../hooks/useAlert";
 import { UseUser } from "../context/UserContext";
 import { Mail } from "lucide-react";
 import { gif } from "../assets";
@@ -9,7 +10,7 @@ export default function ForgotPasswordForm({ switchToLogin }) {
   const [email, setEmail] = useState("");
   const [sent, setSent] = useState(false);
   const { setMessage } = UseUser();
-  const [alert, setAlert] = useState({ type: "", message: "" });
+  const { alert, setAlert, delayedClearAlert } = useAlert();
 
   const { isLoading, error, performFetch } = useFetch(
     "/users/forgot-password",
@@ -22,12 +23,9 @@ export default function ForgotPasswordForm({ switchToLogin }) {
   useEffect(() => {
     if (error) {
       setAlert({ type: "error", message: String(error) });
-      const timer = setTimeout(() => {
-        setAlert({ type: "", message: "" });
-      }, 2000);
-      return () => clearTimeout(timer);
+      delayedClearAlert();
     }
-  }, [error]);
+  }, [error, setAlert, delayedClearAlert]);
 
   async function handleSubmit(e) {
     e.preventDefault(); // Prevent page reload when the form is submitted

--- a/client/src/pages/LoginForm.jsx
+++ b/client/src/pages/LoginForm.jsx
@@ -4,6 +4,7 @@ import { UseUser } from "../context/UserContext";
 import AlertMessage from "../components/AlertMessage/AlertMessage";
 import { gif } from "../assets";
 import useFetch from "../hooks/useFetch";
+import useAlert from "../hooks/useAlert";
 import DonationPopup from "../components/DonationPopup/DonationPopup";
 
 export default function LoginForm({
@@ -13,13 +14,9 @@ export default function LoginForm({
 }) {
   const [loginData, setLoginData] = useState({ email: "", password: "" });
   const [showPassword, setShowPassword] = useState(false);
-  const [alert, setAlert] = useState({ type: "", message: "" });
+  const { alert, setAlert, clearAlert } = useAlert();
   const [donationPopup, setDonationPopup] = useState(false);
   const { dispatch } = UseUser();
-
-  function handleClearAlert() {
-    setAlert({ type: "", message: "" });
-  }
 
   function handleLoginResults(data) {
     const favoriteJobs = Array.isArray(data.user.favorites)
@@ -74,7 +71,7 @@ export default function LoginForm({
   function handleChange(e) {
     const { name, value } = e.target;
     setLoginData({ ...loginData, [name]: value });
-    handleClearAlert();
+    clearAlert();
   }
 
   async function handleSubmit(e) {

--- a/client/src/pages/Profile/Profile.jsx
+++ b/client/src/pages/Profile/Profile.jsx
@@ -190,7 +190,10 @@ export default function Profile() {
 
       <div className="profile-avatar-row">
         {/* <!-- Avatar with the editing/updating button --> */}
-        <AvatarUploader setAlert={setAlert} delayedClearAlert={delayedClearAlert} />
+        <AvatarUploader
+          setAlert={setAlert}
+          delayedClearAlert={delayedClearAlert}
+        />
         <div className="avatar-uploader-info">
           <h3 className="avatar-uploader-title">Profile photo</h3>
           <span className="avatar-uploader-subtitle">

--- a/client/src/pages/Profile/Profile.jsx
+++ b/client/src/pages/Profile/Profile.jsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react";
+import useAlert from "../../hooks/useAlert";
 import SkillsSettings from "../../components/SkillsSettings/SkillsSettings";
 import AddressSettings from "../../components/AddressSettings/AddressSettings";
 import AlertMessage from "../../components/AlertMessage/AlertMessage";
@@ -14,12 +15,11 @@ import { UseUser } from "../../context/UserContext";
 import useFetch from "../../hooks/useFetch";
 import AvatarUploader from "../../components/AvatarUploader/AvatarUploader";
 import DeleteProfilePopup from "../../components/DeleteProfilePopup/DeleteProfilePopup";
-import { DELAYED_CLEAR_INTERVAL } from "../../util/constants";
 import "./Profile.css";
 import { gif } from "../../assets/index.js";
 
 export default function Profile() {
-  const [alert, setAlert] = useState({ type: "", message: "" });
+  const { alert, setAlert, clearAlert, delayedClearAlert } = useAlert();
   const first_nameInputRef = useRef("");
   const last_nameInputRef = useRef("");
   const streetInputRef = useRef("");
@@ -31,16 +31,6 @@ export default function Profile() {
   const confirmPasswordInputRef = useRef("");
   const { user, dispatch } = UseUser();
   const [showDeletePopup, setShowDeletePopup] = useState(false);
-
-  function handleClearAlert() {
-    setAlert({ type: "", message: "" });
-  }
-
-  function delayedClearAlert() {
-    setTimeout(() => {
-      handleClearAlert();
-    }, DELAYED_CLEAR_INTERVAL);
-  }
 
   useEffect(() => {
     if (!user) return;
@@ -129,7 +119,7 @@ export default function Profile() {
   }
 
   function handleSaveClick() {
-    handleClearAlert();
+    clearAlert();
 
     const { passwordValidationError, currentPassword, newPassword } =
       getPasswordChangeValues();
@@ -200,7 +190,7 @@ export default function Profile() {
 
       <div className="profile-avatar-row">
         {/* <!-- Avatar with the editing/updating button --> */}
-        <AvatarUploader setAlert={setAlert} />
+        <AvatarUploader setAlert={setAlert} delayedClearAlert={delayedClearAlert} />
         <div className="avatar-uploader-info">
           <h3 className="avatar-uploader-title">Profile photo</h3>
           <span className="avatar-uploader-subtitle">
@@ -221,7 +211,7 @@ export default function Profile() {
               defaultValue={user?.first_name || ""}
               className="profile-input"
               onKeyDown={pressEnterKey}
-              onChange={handleClearAlert}
+              onChange={clearAlert}
             />
           </div>
           <div className="profile-info">
@@ -232,7 +222,7 @@ export default function Profile() {
               defaultValue={user?.last_name || ""}
               className="profile-input"
               onKeyDown={pressEnterKey}
-              onChange={handleClearAlert}
+              onChange={clearAlert}
             />
           </div>
         </div>
@@ -245,13 +235,13 @@ export default function Profile() {
           houseInputRef={houseInputRef}
           cityInputRef={cityInputRef}
           countryInputRef={countryInputRef}
-          clearAlert={handleClearAlert}
+          clearAlert={clearAlert}
         />
       </div>
 
       <ChangePassword
         onKeyDown={pressEnterKey}
-        clearAlert={handleClearAlert}
+        clearAlert={clearAlert}
         currentPasswordInputRef={currentPasswordInputRef}
         newPasswordInputRef={newPasswordInputRef}
         confirmPasswordInputRef={confirmPasswordInputRef}

--- a/client/src/pages/ResetPassword.jsx
+++ b/client/src/pages/ResetPassword.jsx
@@ -31,12 +31,12 @@ export default function ResetPasswordForm() {
 
   useEffect(() => {
     if (error) {
-      setResetSuccess(false);
+      const reset = () => setResetSuccess(false);
+      reset();
       setAlert({ type: "error", message: String(error) });
       delayedClearAlert();
     }
-  }, [error, setAlert, setResetSuccess, delayedClearAlert]);
-
+  }, [error, setAlert, delayedClearAlert]);
   async function handleSubmit(e) {
     e.preventDefault();
     if (!token) {

--- a/client/src/pages/ResetPassword.jsx
+++ b/client/src/pages/ResetPassword.jsx
@@ -3,6 +3,7 @@ import { useSearchParams, useNavigate } from "react-router-dom";
 import { Eye, EyeOff } from "lucide-react";
 
 import useFetch from "../hooks/useFetch";
+import useAlert from "../hooks/useAlert";
 import AlertMessage from "../components/AlertMessage/AlertMessage";
 import {
   validatePassword,
@@ -15,7 +16,7 @@ export default function ResetPasswordForm() {
   const token = searchParams.get("token");
   const navigate = useNavigate();
   const [resetSuccess, setResetSuccess] = useState(false);
-  const [alert, setAlert] = useState({ type: "", message: "" });
+  const { alert, setAlert, delayedClearAlert } = useAlert();
 
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -30,15 +31,11 @@ export default function ResetPasswordForm() {
 
   useEffect(() => {
     if (error) {
-      (async () => {
-        setResetSuccess(false);
-        setAlert({ type: "error", message: String(error) });
-        setTimeout(() => {
-          setAlert({ type: "", message: "" });
-        }, 2000);
-      })();
+      setResetSuccess(false);
+      setAlert({ type: "error", message: String(error) });
+      delayedClearAlert();
     }
-  }, [error, setAlert, setResetSuccess]);
+  }, [error, setAlert, setResetSuccess, delayedClearAlert]);
 
   async function handleSubmit(e) {
     e.preventDefault();

--- a/client/src/pages/SignupForm.jsx
+++ b/client/src/pages/SignupForm.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import useAlert from "../hooks/useAlert";
 import {
   UserPlus,
   CheckCircle,
@@ -41,15 +42,11 @@ export default function SignupForm({ setSignupSuccessPopup, switchToLogin }) {
     password: "",
     confirmPassword: "",
   });
-  const [alert, setAlert] = useState({ type: "", message: "" });
+  const { alert, setAlert, clearAlert } = useAlert();
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmationPassword, setShowConfirmationPassword] =
     useState(false);
   const { dispatch } = UseUser();
-
-  function handleClearAlert() {
-    setAlert({ type: "", message: "" });
-  }
 
   function handleSignupResults(data) {
     dispatch({
@@ -78,7 +75,7 @@ export default function SignupForm({ setSignupSuccessPopup, switchToLogin }) {
   function handleChange(e) {
     const { name, value } = e.target;
     setSignupData({ ...signupData, [name]: value });
-    handleClearAlert();
+    clearAlert();
   }
 
   async function handleSubmit(e) {
@@ -288,7 +285,7 @@ export default function SignupForm({ setSignupSuccessPopup, switchToLogin }) {
           className="switch-link"
           onClick={() => {
             switchToLogin();
-            handleClearAlert();
+            clearAlert();
           }}
         >
           Login

--- a/client/src/pages/openPositions/OpenPositions.jsx
+++ b/client/src/pages/openPositions/OpenPositions.jsx
@@ -1,5 +1,6 @@
 // React hooks
 import { useMemo, useState, useEffect } from "react";
+import useAlert from "../../hooks/useAlert";
 // Lucide React icons
 import {
   GraduationCap,
@@ -20,7 +21,6 @@ import { UseJobs } from "../../context/JobsContext";
 import { UseUser } from "../../context/UserContext";
 // Utils
 import createSortComparator from "../../util/createSortComparator";
-import { DELAYED_CLEAR_INTERVAL } from "../../util/constants";
 import { findFilterOptions, filterJobs } from "../../util/filterJobs";
 import getSkillsInDescription from "../../util/getSkillsInDescription";
 // Assets
@@ -30,7 +30,7 @@ import "./OpenPositions.css";
 
 export default function OpenPositions() {
   const { user } = UseUser();
-  const [alert, setAlert] = useState({ type: "", message: "" });
+  const { alert, setAlert, delayedClearAlert } = useAlert();
 
   const {
     allJobs,
@@ -61,16 +61,6 @@ export default function OpenPositions() {
     "Most skill matches",
     "Newest first",
   ]);
-
-  function handleClearAlert() {
-    setAlert({ type: "", message: "" });
-  }
-
-  function delayedClearAlert() {
-    setTimeout(() => {
-      handleClearAlert();
-    }, DELAYED_CLEAR_INTERVAL);
-  }
 
   useEffect(() => {
     if (jobFetchError) {


### PR DESCRIPTION
I moved the repeated “show alert  clear alert  auto-clear after a few seconds” logic into one hook called useAlert. Then I updated all places that handled alerts manually like login, signup, profile, open positions, skills, search, and avatar upload to use this hook.
Now there is one central place managing the alert state and the auto-clear timing, and the rest of the app just calls the hook instead of duplicating the logic.