### PR TITLE
Validate job persist job search refactoring

### DIFF
--- a/server/src/controllers/changeSkills.js
+++ b/server/src/controllers/changeSkills.js
@@ -26,7 +26,6 @@ export default async function changeSkills(req, res, next) {
 
   const { connectedClient, endConnection, error } = await connectNeonDB();
   if (error) {
-    if (endConnection) await endConnection();
     logError(`DB Connection Error: ${error}`);
     return next(createHttpError(503, "DB Connection Error"));
   }

--- a/server/src/controllers/deleteUser.js
+++ b/server/src/controllers/deleteUser.js
@@ -25,7 +25,6 @@ export default async function deleteUser(req, res, next) {
   // Connect to the database
   const { error, connectedClient, endConnection } = await connectNeonDB();
   if (error) {
-    if (endConnection) await endConnection();
     logError(`DB Connection Error: ${error}`);
     return next(createHttpError(503, "DB Connection Error"));
   }

--- a/server/src/controllers/forgotPassword.js
+++ b/server/src/controllers/forgotPassword.js
@@ -21,7 +21,6 @@ export default async function forgotPassword(req, res, next) {
 
   const { connectedClient, endConnection, error } = await connectNeonDB();
   if (error) {
-    if (endConnection) await endConnection();
     logError(`DB Connection Error: ${error}`);
     return next(createHttpError(503, "DB Connection Error"));
   }

--- a/server/src/controllers/jobData.js
+++ b/server/src/controllers/jobData.js
@@ -15,7 +15,6 @@ export default async function searchJobs(req, res, next) {
   } = await connectNeonDB();
 
   if (connectionError) {
-    if (endConnection) await endConnection();
     logError(`DB Connection Error: ${connectionError}`);
     return next(createHttpError(503, "DB Connection Error"));
   } else {

--- a/server/src/controllers/jobData.js
+++ b/server/src/controllers/jobData.js
@@ -42,12 +42,10 @@ export default async function searchJobs(req, res, next) {
         is_auth,
       );
 
-    if (cachedJobsPerSearchString.length > 0) {
-      cachedJobsPerSearchString.forEach((job) => {
-        aggregatedJobs.push(job);
-        if (job.id) aggregatedJobsIdsSet.add(job.id);
-      });
-    }
+    cachedJobsPerSearchString.forEach((job) => {
+      aggregatedJobs.push(job);
+      if (job.id) aggregatedJobsIdsSet.add(job.id);
+    });
 
     const msg = apifyScraperFetchPersister(
       search_string,

--- a/server/src/controllers/jobData.js
+++ b/server/src/controllers/jobData.js
@@ -42,10 +42,12 @@ export default async function searchJobs(req, res, next) {
         is_auth,
       );
 
-    cachedJobsPerSearchString.forEach((job) => {
-      aggregatedJobs.push(job);
-      if (job.id) aggregatedJobsIdsSet.add(job.id);
-    });
+    for (const job of cachedJobsPerSearchString) {
+      if (!aggregatedJobsIdsSet.has(job.id)) {
+        aggregatedJobs.push(job);
+        aggregatedJobsIdsSet.add(job.id);
+      }
+    }
 
     const msg = apifyScraperFetchPersister(
       search_string,
@@ -68,7 +70,7 @@ export default async function searchJobs(req, res, next) {
         }
 
         for (const job of fetchedJobs) {
-          if (job.id && !aggregatedJobsIdsSet.has(job.id)) {
+          if (!aggregatedJobsIdsSet.has(job.id)) {
             aggregatedJobs.push(job);
             aggregatedJobsIdsSet.add(job.id);
           }

--- a/server/src/controllers/jobData.js
+++ b/server/src/controllers/jobData.js
@@ -34,6 +34,7 @@ export default async function searchJobs(req, res, next) {
     }
 
     search_string = search_string.toLowerCase();
+    // is_whole_string parameter shows whether the previous search was performed for the whole string, part of it or not at all (undefined)
     const { is_whole_string, cachedJobsPerSearchString } =
       await getCachedJobsBySearchString(
         connectedClient,
@@ -55,7 +56,7 @@ export default async function searchJobs(req, res, next) {
     );
 
     const searchWords = search_string.split(/[\s\-/]+/).filter(Boolean);
-    // If the DB has already responded with the job title which is the single keyword, there's no need to break it down further and re-query for the same keyword.
+    // If the same search was performed before, then the DB has already responded search_string which cannot be undefined, which means that it is worth to query the DB further only if the search string contains multiple words
     if (is_whole_string === undefined || searchWords.length > 1) {
       for (const searchWord of searchWords) {
         const cachedResult = await getCachedJobsBySearchString(

--- a/server/src/controllers/jobData.js
+++ b/server/src/controllers/jobData.js
@@ -57,15 +57,13 @@ export default async function searchJobs(req, res, next) {
     // If the same search was performed before, then the DB has already responded search_string which cannot be undefined, which means that it is worth to query the DB further only if the search string contains multiple words
     if (is_whole_string === undefined || searchWords.length > 1) {
       for (const searchWord of searchWords) {
-        const cachedResult = await getCachedJobsBySearchString(
-          connectedClient,
-          searchWord,
-          is_auth,
-        );
-        let fetchedJobs = [];
-        if (cachedResult.cachedJobsPerSearchString.length > 0) {
-          fetchedJobs = cachedResult.cachedJobsPerSearchString;
-        } else {
+        let { cachedJobsPerSearchString: fetchedJobs } =
+          await getCachedJobsBySearchString(
+            connectedClient,
+            searchWord,
+            is_auth,
+          );
+        if (fetchedJobs.length === 0) {
           fetchedJobs = await rapidAPIfetchPersister(searchWord, is_auth);
         }
 

--- a/server/src/controllers/jobData.js
+++ b/server/src/controllers/jobData.js
@@ -17,81 +17,81 @@ export default async function searchJobs(req, res, next) {
   if (connectionError) {
     logError(`DB Connection Error: ${connectionError}`);
     return next(createHttpError(503, "DB Connection Error"));
-  } else {
-    try {
-      let { search_string } = req.body;
-      let aggregatedJobs = [];
-      const aggregatedJobsIdsSet = new Set();
+  }
 
-      if (typeof search_string !== "string" || !search_string.trim()) {
-        return next(
-          createHttpError(
-            400,
-            "You need to provide 'search_string' (non-empty string) in the request body.",
-          ),
-        );
-      }
+  try {
+    let { search_string } = req.body;
+    let aggregatedJobs = [];
+    const aggregatedJobsIdsSet = new Set();
 
-      search_string = search_string.toLowerCase();
-      const { is_whole_string, cachedJobsPerSearchString } =
-        await getCachedJobsBySearchString(
-          connectedClient,
-          search_string,
-          is_auth,
-        );
+    if (typeof search_string !== "string" || !search_string.trim()) {
+      return next(
+        createHttpError(
+          400,
+          "You need to provide 'search_string' (non-empty string) in the request body.",
+        ),
+      );
+    }
 
-      if (cachedJobsPerSearchString.length > 0) {
-        cachedJobsPerSearchString.forEach((job) => {
-          aggregatedJobs.push(job);
-          if (job.id) aggregatedJobsIdsSet.add(job.id);
-        });
-      }
-
-      const msg = apifyScraperFetchPersister(
+    search_string = search_string.toLowerCase();
+    const { is_whole_string, cachedJobsPerSearchString } =
+      await getCachedJobsBySearchString(
+        connectedClient,
         search_string,
-        is_whole_string,
         is_auth,
       );
 
-      const searchWords = search_string.split(/[\s\-/]+/).filter(Boolean);
-      // If the DB has already responded with the job title which is the single keyword, there's no need to break it down further and re-query for the same keyword.
-      if (is_whole_string === undefined || searchWords.length > 1) {
-        for (const searchWord of searchWords) {
-          const cachedResult = await getCachedJobsBySearchString(
-            connectedClient,
-            searchWord,
-            is_auth,
-          );
-          let fetchedJobs = [];
-          if (cachedResult.cachedJobsPerSearchString.length > 0) {
-            fetchedJobs = cachedResult.cachedJobsPerSearchString;
-          } else {
-            fetchedJobs = await rapidAPIfetchPersister(searchWord, is_auth);
-          }
+    if (cachedJobsPerSearchString.length > 0) {
+      cachedJobsPerSearchString.forEach((job) => {
+        aggregatedJobs.push(job);
+        if (job.id) aggregatedJobsIdsSet.add(job.id);
+      });
+    }
 
-          for (const job of fetchedJobs) {
-            if (job.id && !aggregatedJobsIdsSet.has(job.id)) {
-              aggregatedJobs.push(job);
-              aggregatedJobsIdsSet.add(job.id);
-            }
+    const msg = apifyScraperFetchPersister(
+      search_string,
+      is_whole_string,
+      is_auth,
+    );
+
+    const searchWords = search_string.split(/[\s\-/]+/).filter(Boolean);
+    // If the DB has already responded with the job title which is the single keyword, there's no need to break it down further and re-query for the same keyword.
+    if (is_whole_string === undefined || searchWords.length > 1) {
+      for (const searchWord of searchWords) {
+        const cachedResult = await getCachedJobsBySearchString(
+          connectedClient,
+          searchWord,
+          is_auth,
+        );
+        let fetchedJobs = [];
+        if (cachedResult.cachedJobsPerSearchString.length > 0) {
+          fetchedJobs = cachedResult.cachedJobsPerSearchString;
+        } else {
+          fetchedJobs = await rapidAPIfetchPersister(searchWord, is_auth);
+        }
+
+        for (const job of fetchedJobs) {
+          if (job.id && !aggregatedJobsIdsSet.has(job.id)) {
+            aggregatedJobs.push(job);
+            aggregatedJobsIdsSet.add(job.id);
           }
         }
       }
-
-      return res.status(200).json({
-        success: true,
-        result: aggregatedJobs,
-        msg,
-      });
-    } catch (error) {
-      return next(
-        createHttpError(
-          500,
-          "Unable to search for jobs, please try again later.",
-        ),
-      );
-    } finally {
-      if (endConnection) await endConnection();
     }
+
+    return res.status(200).json({
+      success: true,
+      result: aggregatedJobs,
+      msg,
+    });
+  } catch (error) {
+    return next(
+      createHttpError(
+        500,
+        "Unable to search for jobs, please try again later.",
+      ),
+    );
+  } finally {
+    if (endConnection) await endConnection();
   }
 }

--- a/server/src/controllers/profile.js
+++ b/server/src/controllers/profile.js
@@ -60,7 +60,6 @@ export default async function updateUserProfile(user_id, fieldsToUpdate) {
 
   const { connectedClient, endConnection, error } = await connectNeonDB();
   if (error) {
-    if (endConnection) await endConnection();
     logError(`DB Connection Error: ${error}`);
     throw createHttpError(503, "DB Connection Error");
   }

--- a/server/src/controllers/resetPassword.js
+++ b/server/src/controllers/resetPassword.js
@@ -13,7 +13,6 @@ export default async function resetPassword(req, res, next) {
   const { connectedClient, endConnection, error } = await connectNeonDB();
 
   if (error) {
-    if (endConnection) await endConnection();
     logError(`DB Connection Error: ${error}`);
     return next(createHttpError(503, "DB Connection Error"));
   }

--- a/server/src/controllers/toggleFavoriteJob.js
+++ b/server/src/controllers/toggleFavoriteJob.js
@@ -42,7 +42,6 @@ export default async function toggleFavoriteJob(req, res, next) {
 
   //  Handle database connection error
   if (error) {
-    if (endConnection) await endConnection();
     logError(`DB Connection Error: ${error}`);
     return next(createHttpError(503, "DB Connection Error"));
   }

--- a/server/src/controllers/user.js
+++ b/server/src/controllers/user.js
@@ -34,7 +34,6 @@ const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN;
 export async function createUser(req, res, next) {
   const { connectedClient, endConnection, error } = await connectNeonDB();
   if (error) {
-    if (endConnection) await endConnection();
     logError(`DB Connection Error: ${error}`);
     return next(createHttpError(503, "DB Connection Error"));
   }
@@ -126,7 +125,6 @@ export async function loginUser(req, res, next) {
   const { connectedClient, endConnection, error } = await connectNeonDB();
 
   if (error) {
-    if (endConnection) await endConnection();
     logError(`DB Connection Error: ${error}`);
     return next(createHttpError(503, "DB Connection Error"));
   }
@@ -218,7 +216,6 @@ export async function logoutUser(req, res, next) {
 export async function getMe(req, res, next) {
   const { connectedClient, endConnection, error } = await connectNeonDB();
   if (error) {
-    if (endConnection) await endConnection();
     logError(`DB Connection Error: ${error}`);
     return next(createHttpError(503, "DB Connection Error"));
   }
@@ -266,7 +263,6 @@ export async function updateUserAvatar(req, res, next) {
   const { connectedClient, endConnection, error } = await connectNeonDB();
 
   if (error) {
-    if (endConnection) await endConnection();
     logError(`DB Connection Error: ${error}`);
     return next(createHttpError(503, "DB Connection Error"));
   }

--- a/server/src/services/apifyScraperFetchPersister.js
+++ b/server/src/services/apifyScraperFetchPersister.js
@@ -12,9 +12,9 @@ export default function apifyScraperFetchPersister(
 ) {
   cleanupInProgress(inProgressScraperFetch, 20 * 60 * 1000);
 
-  if (!is_auth) return null;
-  if (is_whole_string) return null;
-  if (inProgressScraperFetch[search_string]) return null;
+  if (!is_auth || is_whole_string || inProgressScraperFetch[search_string]) {
+    return null;
+  }
 
   inProgressScraperFetch[search_string] = {
     timestamp: Date.now(),

--- a/server/src/services/cleanupDatabase.js
+++ b/server/src/services/cleanupDatabase.js
@@ -25,8 +25,5 @@ export default async function cleanupDatabase() {
     }
   } else {
     logError(`DB Connection Error: ${error}`);
-    if (endConnection) {
-      await endConnection();
-    }
   }
 }

--- a/server/src/services/cleanupDatabase.js
+++ b/server/src/services/cleanupDatabase.js
@@ -4,26 +4,27 @@ import { logError } from "../util/logging.js";
 export default async function cleanupDatabase() {
   const { error, connectedClient, endConnection } = await connectNeonDB();
 
-  if (!error) {
-    try {
-      await connectedClient.query(
-        "DELETE FROM search_strings WHERE search_date < NOW() - INTERVAL '1 week'",
-      );
-      await connectedClient.query(
-        "DELETE FROM jobs WHERE date_posted < NOW() - INTERVAL '1 month' OR (id NOT IN (SELECT job_id FROM search_strings_jobs) AND id NOT IN (SELECT job_id FROM user_favorites))",
-      );
-      await connectedClient.query(
-        "DELETE FROM search_strings_jobs WHERE job_id NOT IN (SELECT id FROM jobs) OR search_string NOT IN (SELECT search_string FROM search_strings)",
-      );
-      await connectedClient.query(
-        "DELETE FROM user_favorites WHERE job_id NOT IN (SELECT id FROM jobs) OR user_id NOT IN (SELECT id FROM users)",
-      );
-    } catch (error) {
-      logError(`Unexpected error during database cleanup: ${error.message}`);
-    } finally {
-      await endConnection();
-    }
-  } else {
+  if (error) {
     logError(`DB Connection Error: ${error}`);
+    return;
+  }
+
+  try {
+    await connectedClient.query(
+      "DELETE FROM search_strings WHERE search_date < NOW() - INTERVAL '1 week'",
+    );
+    await connectedClient.query(
+      "DELETE FROM jobs WHERE date_posted < NOW() - INTERVAL '1 month' OR (id NOT IN (SELECT job_id FROM search_strings_jobs) AND id NOT IN (SELECT job_id FROM user_favorites))",
+    );
+    await connectedClient.query(
+      "DELETE FROM search_strings_jobs WHERE job_id NOT IN (SELECT id FROM jobs) OR search_string NOT IN (SELECT search_string FROM search_strings)",
+    );
+    await connectedClient.query(
+      "DELETE FROM user_favorites WHERE job_id NOT IN (SELECT id FROM jobs) OR user_id NOT IN (SELECT id FROM users)",
+    );
+  } catch (error) {
+    logError(`Unexpected error during database cleanup: ${error.message}`);
+  } finally {
+    await endConnection();
   }
 }

--- a/server/src/services/getCachedJobsBySearchString.js
+++ b/server/src/services/getCachedJobsBySearchString.js
@@ -1,21 +1,36 @@
-/*
-Job Search Integration & Caching Implementation:
-- Multi-API Integration: LinkedIn jobs via RapidAPI and Apify scraper
-- Intelligent Caching: Authentication-aware caching with automatic cleanup
-- Search Optimization: Word-by-word processing for better result coverage
-- Data Normalization: Standardized job data from multiple sources
-- Cache Strategy: Authentication-aware result retrieval with privacy protection
-- Performance: Efficient database queries with proper joins and filtering
-- Analytics Foundation: Supports search pattern analysis and user behavior tracking
-*/
-
 /**
- * Retrieves cached jobs from the database for a given search word
- * @param {Object} connectedClient - Database client connection
- * @param {string} searchWord - The search word to look up
- * @param {string|null} is_auth - Optional user identifier (uuid used as a boolean-ish flag for authenticated requests now, retained for future search analytics); leave null/undefined for anonymous lookups
- * @returns {Promise<Object>} Object containing is_whole_string and cachedJobsPerSearchString array
+ * Retrieves cached job listings associated with a given search string from the database.
+ *
+ * This function queries the database to check if a search string exists and, if found,
+ * retrieves all jobs that have been cached for that particular search term. It supports
+ * both whole string and partial matches, and respects authentication requirements.
+ *
+ * @async
+ * @param {Object} connectedClient - A database client instance with query capability
+ *                                   (typically a PostgreSQL client connection)
+ * @param {string} searchWord - The search string to look up in the cache. This is the
+ *                              term that users searched for previously
+ * @param {string|null} is_auth - Authentication context identifier. If provided, only
+ *                                 jobs marked as requiring authentication will be returned.
+ *                                 If null, all cached jobs are returned regardless of
+ *                                 authentication requirement
+ *
+ * @returns {Promise<Object>} A promise that resolves to an object containing:
+ *   @returns {Promise<Object>} .is_whole_string - Boolean indicating whether the cached
+ *                               search string represents a whole string match (true) or
+ *                               partial match (false). Returns undefined if search string
+ *                               not found in cache
+ *   @returns {Promise<Object>} .cachedJobsPerSearchString - Array of job objects matching
+ *                               the search string. Each job object contains all columns
+ *                               from the jobs table. Returns empty array if no matching
+ *                               jobs are found or if the search string doesn't exist
+ *
+ * @example
+ * const result = await getCachedJobsBySearchString(dbClient, 'React Developer', userId);
+ * console.log(result.is_whole_string); // true or false
+ * console.log(result.cachedJobsPerSearchString); // Array of job objects
  */
+
 export default async function getCachedJobsBySearchString(
   connectedClient,
   searchWord,
@@ -34,6 +49,13 @@ export default async function getCachedJobsBySearchString(
     const isWholeString = checkWordResult.rows[0].is_whole_string;
 
     // Retrieve cached jobs
+    // This query joins three tables to get all jobs associated with a search string:
+    // 1. Selects all job columns (j.*)
+    // 2. Joins with search_strings_jobs to find which jobs match the search string
+    // 3. Joins with search_strings to access auth requirements
+    // 4. Filters by: the specific search string ($1)
+    //    AND either: is_auth from the user is NULL (unauthenticated) OR is_auth from the search string table is not NULL (authenticated previous search)
+    // It forces the function not to return jobs for the authenticated user if the previous search was performed by an unauthenticated user, otherwise the number of jobs will be too few for the authenticated user)
     const cachedJobsResult = await connectedClient.query(
       `SELECT j.* FROM jobs j
        JOIN search_strings_jobs swj ON j.id = swj.job_id

--- a/server/src/services/getCachedJobsBySearchString.js
+++ b/server/src/services/getCachedJobsBySearchString.js
@@ -52,7 +52,7 @@ export default async function getCachedJobsBySearchString(
     // 3. Joins with search_strings to access auth requirements
     // 4. Filters by: the specific search string ($1)
     //    AND either: is_auth from the user is NULL (unauthenticated) OR is_auth from the search string table is not NULL (authenticated previous search)
-    // It forces the function not to return jobs for the authenticated user if the previous search was performed by an unauthenticated user, otherwise the number of jobs will be too few for the authenticated user)
+    // It forces the function not to return jobs for the authenticated user if the previous search was performed by an unauthenticated user, otherwise the number of jobs will be too few for the authenticated user
     const cachedJobsResult = await connectedClient.query(
       `SELECT j.* FROM jobs j
        JOIN search_strings_jobs swj ON j.id = swj.job_id

--- a/server/src/services/getCachedJobsBySearchString.js
+++ b/server/src/services/getCachedJobsBySearchString.js
@@ -6,24 +6,21 @@
  * both whole string and partial matches, and respects authentication requirements.
  *
  * @async
- * @param {Object} connectedClient - A database client instance with query capability
- *                                   (typically a PostgreSQL client connection)
- * @param {string} searchWord - The search string to look up in the cache. This is the
- *                              term that users searched for previously
- * @param {string|null} is_auth - Authentication context identifier. If provided, only
- *                                 jobs marked as requiring authentication will be returned.
- *                                 If null, all cached jobs are returned regardless of
- *                                 authentication requirement
+ * @param {string|null} is_auth - Authentication context identifier used to decide
+ *                                 whether cache entries created from an authenticated
+ *                                 search may be used. If null, any cache entry for the
+ *                                 search string may be returned. If provided, only cache
+ *                                 entries whose stored search_string has a non-null
+ *                                 `ss.is_auth` are eligible.
  *
- * @returns {Promise<Object>} A promise that resolves to an object containing:
- *   @returns {Promise<Object>} .is_whole_string - Boolean indicating whether the cached
- *                               search string represents a whole string match (true) or
- *                               partial match (false). Returns undefined if search string
- *                               not found in cache
- *   @returns {Promise<Object>} .cachedJobsPerSearchString - Array of job objects matching
- *                               the search string. Each job object contains all columns
- *                               from the jobs table. Returns empty array if no matching
- *                               jobs are found or if the search string doesn't exist
+ * @returns {Promise<{is_whole_string: (boolean|undefined), cachedJobsPerSearchString: Object[]}>}
+ * A promise that resolves to the cached search result object.
+ * @property {(boolean|undefined)} is_whole_string - Indicates whether the cached
+ * search string represents a whole string match (`true`) or partial match (`false`).
+ * Returns `undefined` if the search string is not found in cache.
+ * @property {Object[]} cachedJobsPerSearchString - Array of job objects matching the
+ * search string. Each job object contains all columns from the `jobs` table. Returns an
+ * empty array if no matching jobs are found or if the search string does not exist.
  *
  * @example
  * const result = await getCachedJobsBySearchString(dbClient, 'React Developer', userId);

--- a/server/src/services/persistJobSearch.js
+++ b/server/src/services/persistJobSearch.js
@@ -1,5 +1,6 @@
 import { logError } from "../util/logging.js";
 import connectNeonDB from "../db/connectNeonDB.js";
+import validateJob from "../util/validateJob.js";
 
 export default async function persistJobSearch(
   fetchedJobs,
@@ -34,20 +35,8 @@ export default async function persistJobSearch(
       }
 
       // Process all jobs and collect data for batch operations
-      const oneMonthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-
       for (const job of fetchedJobs) {
-        if (
-          !Object.entries(job)
-            .filter(
-              ([key]) =>
-                key !== "travel_time" &&
-                key !== "least_transfers" &&
-                key !== "work_mode",
-            )
-            .some(([, value]) => value === null) &&
-          new Date(job.date_posted) >= oneMonthAgo
-        ) {
+        if (validateJob(job)) {
           if (!idSet.has(job.id)) {
             idSet.add(job.id);
             jobsToInsert.push(job);

--- a/server/src/services/persistJobSearch.js
+++ b/server/src/services/persistJobSearch.js
@@ -14,116 +14,117 @@ export default async function persistJobSearch(
     endConnection,
   } = await connectNeonDB();
 
-  if (!connectionError) {
-    const jobsToInsert = [];
-    const searchStringJobsToInsert = [];
-    const idSet = new Set();
+  if (connectionError) {
+    logError(`DB Connection Error: ${connectionError}`);
+    return;
+  }
 
-    await connectedClient.query("BEGIN");
-    try {
-      // Insert search string
-      if (is_whole_string) {
-        await connectedClient.query(
-          "INSERT INTO search_strings (search_string, search_date, is_auth, is_whole_string) VALUES ($1, NOW(), $2, $3) ON CONFLICT (search_string) DO UPDATE SET search_date = NOW(), is_auth = $2, is_whole_string = $3",
-          [search_string, is_auth, is_whole_string],
-        );
-      } else {
-        await connectedClient.query(
-          "INSERT INTO search_strings (search_string, search_date, is_auth) VALUES ($1, NOW(), $2) ON CONFLICT (search_string) DO UPDATE SET search_date = NOW(), is_auth = $2",
-          [search_string, is_auth],
-        );
-      }
+  const jobsToInsert = [];
+  const searchStringJobsToInsert = [];
+  const idSet = new Set();
 
-      // Process all jobs and collect data for batch operations
-      for (const job of fetchedJobs) {
-        if (validateJob(job)) {
-          if (!idSet.has(job.id)) {
-            idSet.add(job.id);
-            jobsToInsert.push(job);
-            searchStringJobsToInsert.push({
-              search_string,
-              jobId: job.id,
-            });
-          }
+  await connectedClient.query("BEGIN");
+  try {
+    // Insert search string
+    if (is_whole_string) {
+      await connectedClient.query(
+        "INSERT INTO search_strings (search_string, search_date, is_auth, is_whole_string) VALUES ($1, NOW(), $2, $3) ON CONFLICT (search_string) DO UPDATE SET search_date = NOW(), is_auth = $2, is_whole_string = $3",
+        [search_string, is_auth, is_whole_string],
+      );
+    } else {
+      await connectedClient.query(
+        "INSERT INTO search_strings (search_string, search_date, is_auth) VALUES ($1, NOW(), $2) ON CONFLICT (search_string) DO UPDATE SET search_date = NOW(), is_auth = $2",
+        [search_string, is_auth],
+      );
+    }
+
+    // Process all jobs and collect data for batch operations
+    for (const job of fetchedJobs) {
+      if (validateJob(job)) {
+        if (!idSet.has(job.id)) {
+          idSet.add(job.id);
+          jobsToInsert.push(job);
+          searchStringJobsToInsert.push({
+            search_string,
+            jobId: job.id,
+          });
         }
       }
-
-      // Batch insert all jobs with ON CONFLICT handling
-      if (jobsToInsert.length > 0) {
-        const placeholders = jobsToInsert
-          .map((_, i) => {
-            const offset = i * 14;
-            return `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11}, $${offset + 12}, $${offset + 13}, $${offset + 14})`;
-          })
-          .join(", ");
-
-        const values = jobsToInsert.flatMap((job) => [
-          job.id,
-          job.date_posted,
-          job.title,
-          job.organization,
-          job.organization_url,
-          job.employment_type,
-          job.url,
-          job.organization_logo,
-          job.display_location,
-          job.work_mode,
-          job.seniority,
-          job.description_text,
-          job.normalized_description,
-          job.language,
-        ]);
-
-        const insertJobsQuery = `
-        INSERT INTO jobs (
-          id, date_posted, title, organization, organization_url,
-          employment_type, url, organization_logo, display_location,
-          work_mode, seniority, description_text, normalized_description, language
-        ) VALUES ${placeholders}
-        ON CONFLICT (id) DO UPDATE SET
-          work_mode = CASE
-            WHEN EXCLUDED.work_mode IS NOT NULL THEN EXCLUDED.work_mode
-            ELSE jobs.work_mode
-          END,
-          description_text = CASE
-            WHEN EXCLUDED.description_text ~ '<[^>]+>' THEN EXCLUDED.description_text
-            ELSE jobs.description_text
-          END
-      `;
-
-        await connectedClient.query(insertJobsQuery, values);
-      }
-
-      // Batch insert all search_strings_jobs relationships
-      if (searchStringJobsToInsert.length > 0) {
-        const placeholders = searchStringJobsToInsert
-          .map((_, i) => `($${i * 2 + 1}, $${i * 2 + 2})`)
-          .join(", ");
-
-        const values = searchStringJobsToInsert.flatMap((rel) => [
-          rel.search_string,
-          rel.jobId,
-        ]);
-
-        const insertRelationsQuery = `
-        INSERT INTO search_strings_jobs (search_string, job_id) VALUES ${placeholders}
-        ON CONFLICT DO NOTHING
-      `;
-
-        await connectedClient.query(insertRelationsQuery, values);
-      }
-
-      await connectedClient.query("COMMIT");
-    } catch (error) {
-      try {
-        await connectedClient.query("ROLLBACK");
-      } catch (rollbackError) {
-        logError(`Rollback error in persistJobSearch: ${rollbackError}`);
-      }
-      logError(`Transaction error: ${error}`);
     }
-  } else {
-    logError(`DB Connection Error: ${connectionError}`);
+
+    // Batch insert all jobs with ON CONFLICT handling
+    if (jobsToInsert.length > 0) {
+      const placeholders = jobsToInsert
+        .map((_, i) => {
+          const offset = i * 14;
+          return `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11}, $${offset + 12}, $${offset + 13}, $${offset + 14})`;
+        })
+        .join(", ");
+
+      const values = jobsToInsert.flatMap((job) => [
+        job.id,
+        job.date_posted,
+        job.title,
+        job.organization,
+        job.organization_url,
+        job.employment_type,
+        job.url,
+        job.organization_logo,
+        job.display_location,
+        job.work_mode,
+        job.seniority,
+        job.description_text,
+        job.normalized_description,
+        job.language,
+      ]);
+
+      const insertJobsQuery = `
+      INSERT INTO jobs (
+        id, date_posted, title, organization, organization_url,
+        employment_type, url, organization_logo, display_location,
+        work_mode, seniority, description_text, normalized_description, language
+      ) VALUES ${placeholders}
+      ON CONFLICT (id) DO UPDATE SET
+        work_mode = CASE
+          WHEN EXCLUDED.work_mode IS NOT NULL THEN EXCLUDED.work_mode
+          ELSE jobs.work_mode
+        END,
+        description_text = CASE
+          WHEN EXCLUDED.description_text ~ '<[^>]+>' THEN EXCLUDED.description_text
+          ELSE jobs.description_text
+        END
+    `;
+
+      await connectedClient.query(insertJobsQuery, values);
+    }
+
+    // Batch insert all search_strings_jobs relationships
+    if (searchStringJobsToInsert.length > 0) {
+      const placeholders = searchStringJobsToInsert
+        .map((_, i) => `($${i * 2 + 1}, $${i * 2 + 2})`)
+        .join(", ");
+
+      const values = searchStringJobsToInsert.flatMap((rel) => [
+        rel.search_string,
+        rel.jobId,
+      ]);
+
+      const insertRelationsQuery = `
+      INSERT INTO search_strings_jobs (search_string, job_id) VALUES ${placeholders}
+      ON CONFLICT DO NOTHING
+    `;
+
+      await connectedClient.query(insertRelationsQuery, values);
+    }
+
+    await connectedClient.query("COMMIT");
+  } catch (error) {
+    try {
+      await connectedClient.query("ROLLBACK");
+    } catch (rollbackError) {
+      logError(`Rollback error in persistJobSearch: ${rollbackError}`);
+    }
+    logError(`Transaction error: ${error}`);
   }
 
   if (endConnection) await endConnection();

--- a/server/src/util/cleanupInProgress.js
+++ b/server/src/util/cleanupInProgress.js
@@ -6,7 +6,7 @@
 export default function cleanupInProgress(inProgressSearch, expirationTime) {
   const currentTime = Date.now();
 
-  // Clean up inProgressSearch (entries older than 3 minutes)
+  // Clean up inProgressSearch object from older entries
   for (const key in inProgressSearch) {
     if (currentTime - inProgressSearch[key].timestamp > expirationTime) {
       delete inProgressSearch[key];

--- a/server/src/util/map_user_details_with_favorites.js
+++ b/server/src/util/map_user_details_with_favorites.js
@@ -1,6 +1,4 @@
 export function mapUserFavoritesFromRows(rows) {
-  if (!rows.length) return [];
-
   const favorites = [];
   rows.forEach((row) => {
     if (row.job_id) {

--- a/server/src/util/validateJob.js
+++ b/server/src/util/validateJob.js
@@ -4,35 +4,19 @@
  * @returns {boolean} - True if the job is valid, false otherwise
  */
 export default function validateJob(job) {
-  // Ensure a job object exists to avoid runtime errors
   if (!job || typeof job !== "object") {
     return false;
   }
 
-  // Validate the presence and correctness of date_posted
   const datePosted = new Date(job.date_posted);
-  if (!Number.isFinite(datePosted.getTime())) {
-    return false;
-  }
-
-  // Check if job date is within the last 30 days
   const oneMonthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-  if (datePosted < oneMonthAgo) {
+  if (!Number.isFinite(datePosted.getTime()) || datePosted < oneMonthAgo) {
     return false;
   }
 
-  // Check if all required fields are non-null
-  // (excluding travel_time, least_transfers, and work_mode)
-  const hasNullValues = Object.entries(job)
-    .filter(
-      ([key]) =>
-        key !== "travel_time" &&
-        key !== "least_transfers" &&
-        key !== "work_mode",
-    )
-    .some(([, value]) => {
-      return value === null || value === undefined;
-    });
-
-  return !hasNullValues;
+  const optionalFields = ["travel_time", "least_transfers", "work_mode"];
+  return Object.entries(job).every(([key, value]) => {
+    if (optionalFields.includes(key)) return true;
+    return value !== null && value !== undefined;
+  });
 }

--- a/server/src/util/validateJob.js
+++ b/server/src/util/validateJob.js
@@ -10,7 +10,7 @@ export default function validateJob(job) {
 
   const datePosted = new Date(job.date_posted);
   const oneMonthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-  if (!Number.isFinite(datePosted.getTime()) || datePosted < oneMonthAgo) {
+  if (isNaN(datePosted) || datePosted < oneMonthAgo) {
     return false;
   }
 


### PR DESCRIPTION
## Pull request overview

Refactors the job search persistence/caching flow by centralizing job validation, simplifying connection-error handling, and improving/adjusting documentation and in-progress cleanup behavior across services/controllers.

**Changes:**
- Reused `validateJob` in `persistJobSearch` to centralize filtering of persisted jobs.
- Simplified DB connection error branches in multiple controllers/services (early returns, fewer redundant `endConnection` calls).
- Updated/expanded documentation and comments in caching and cleanup utilities.