### PR TITLE
refactor: share SuccessPopup layout across login/signup/job popups

### DIFF
--- a/client/src/components/SuccessPopup/LoginSuccessPopup.jsx
+++ b/client/src/components/SuccessPopup/LoginSuccessPopup.jsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import handleKeyDown from "../../util/handleKeyDown";
+import SuccessPopup from "./SuccessPopup";
 
 export default function LoginSuccessPopup({ onClose }) {
   const navigate = useNavigate();
@@ -10,21 +11,19 @@ export default function LoginSuccessPopup({ onClose }) {
   }
 
   return (
-    <div className="popup-overlay">
-      <div className="popup-card">
-        <h2>Success!</h2>
-        <p>You successfully logged in!</p>
-        <div className="popup-buttons">
-          <button
-            className="btn-primary"
-            autoFocus
-            onClick={handleContinue}
-            onKeyDown={(e) => handleKeyDown(e, handleContinue)}
-          >
-            Continue
-          </button>
-        </div>
+    <SuccessPopup>
+      <h2>Success!</h2>
+      <p>You successfully logged in!</p>
+      <div className="popup-buttons">
+        <button
+          className="btn-primary"
+          autoFocus
+          onClick={handleContinue}
+          onKeyDown={(e) => handleKeyDown(e, handleContinue)}
+        >
+          Continue
+        </button>
       </div>
-    </div>
+    </SuccessPopup>
   );
 }

--- a/client/src/components/SuccessPopup/PopupForFavorites.jsx
+++ b/client/src/components/SuccessPopup/PopupForFavorites.jsx
@@ -1,32 +1,31 @@
 import handleKeyDown from "../../util/handleKeyDown";
+import SuccessPopup from "./SuccessPopup";
 
 export default function PopupForFavorites({
   handleLoginRedirect,
   setShowPopup,
 }) {
   return (
-    <div className="popup-overlay">
-      <div className="popup-card">
-        <h2>Want to save this job post for later?</h2>
-        <p>Log in to hop on board!</p>
-        <div className="popup-buttons">
-          <button
-            className="btn-primary"
-            autoFocus
-            onClick={handleLoginRedirect}
-            onKeyDown={(e) => handleKeyDown(e, handleLoginRedirect)}
-          >
-            Log in
-          </button>
-          <button
-            className="btn-secondary"
-            onClick={() => setShowPopup(false)}
-            onKeyDown={(e) => handleKeyDown(e, () => setShowPopup(false))}
-          >
-            Cancel
-          </button>
-        </div>
+    <SuccessPopup>
+      <h2>Want to save this job post for later?</h2>
+      <p>Log in to hop on board!</p>
+      <div className="popup-buttons">
+        <button
+          className="btn-primary"
+          autoFocus
+          onClick={handleLoginRedirect}
+          onKeyDown={(e) => handleKeyDown(e, handleLoginRedirect)}
+        >
+          Log in
+        </button>
+        <button
+          className="btn-secondary"
+          onClick={() => setShowPopup(false)}
+          onKeyDown={(e) => handleKeyDown(e, () => setShowPopup(false))}
+        >
+          Cancel
+        </button>
       </div>
-    </div>
+    </SuccessPopup>
   );
 }

--- a/client/src/components/SuccessPopup/PopupForMoreAndApply.jsx
+++ b/client/src/components/SuccessPopup/PopupForMoreAndApply.jsx
@@ -1,32 +1,31 @@
 import handleKeyDown from "../../util/handleKeyDown";
+import SuccessPopup from "./SuccessPopup";
 
 export default function PopupForMoreAndApply({
   handleLoginRedirect,
   setShowPopup,
 }) {
   return (
-    <div className="popup-overlay">
-      <div className="popup-card">
-        <h2>Want to apply for this job?</h2>
-        <p>Log in to hop on board!</p>
-        <div className="popup-buttons">
-          <button
-            className="btn-primary"
-            autoFocus
-            onClick={handleLoginRedirect}
-            onKeyDown={(e) => handleKeyDown(e, handleLoginRedirect)}
-          >
-            Log in
-          </button>
-          <button
-            className="btn-secondary"
-            onClick={() => setShowPopup(false)}
-            onKeyDown={(e) => handleKeyDown(e, () => setShowPopup(false))}
-          >
-            Cancel
-          </button>
-        </div>
+    <SuccessPopup>
+      <h2>Want to apply for this job?</h2>
+      <p>Log in to hop on board!</p>
+      <div className="popup-buttons">
+        <button
+          className="btn-primary"
+          autoFocus
+          onClick={handleLoginRedirect}
+          onKeyDown={(e) => handleKeyDown(e, handleLoginRedirect)}
+        >
+          Log in
+        </button>
+        <button
+          className="btn-secondary"
+          onClick={() => setShowPopup(false)}
+          onKeyDown={(e) => handleKeyDown(e, () => setShowPopup(false))}
+        >
+          Cancel
+        </button>
       </div>
-    </div>
+    </SuccessPopup>
   );
 }

--- a/client/src/components/SuccessPopup/PopupForSave.jsx
+++ b/client/src/components/SuccessPopup/PopupForSave.jsx
@@ -1,5 +1,5 @@
-import "../JobCard/JobCard.css";
 import handleKeyDown from "../../util/handleKeyDown";
+import SuccessPopup from "./SuccessPopup";
 
 export default function PopupForSave({
   title = "Want to save your settings?",
@@ -8,27 +8,25 @@ export default function PopupForSave({
   setShowSavePopup,
 }) {
   return (
-    <div className="popup-overlay">
-      <div className="popup-card">
-        <h2>{title}</h2>
-        <p>{message}</p>
-        <div className="popup-buttons">
-          <button
-            className="btn-primary"
-            onClick={handleLoginRedirect}
-            onKeyDown={(e) => handleKeyDown(e, handleLoginRedirect)}
-          >
-            Log in
-          </button>
-          <button
-            className="btn-secondary"
-            onClick={() => setShowSavePopup(false)}
-            onKeyDown={(e) => handleKeyDown(e, () => setShowSavePopup(false))}
-          >
-            Cancel
-          </button>
-        </div>
+    <SuccessPopup>
+      <h2>{title}</h2>
+      <p>{message}</p>
+      <div className="popup-buttons">
+        <button
+          className="btn-primary"
+          onClick={handleLoginRedirect}
+          onKeyDown={(e) => handleKeyDown(e, handleLoginRedirect)}
+        >
+          Log in
+        </button>
+        <button
+          className="btn-secondary"
+          onClick={() => setShowSavePopup(false)}
+          onKeyDown={(e) => handleKeyDown(e, () => setShowSavePopup(false))}
+        >
+          Cancel
+        </button>
       </div>
-    </div>
+    </SuccessPopup>
   );
 }

--- a/client/src/components/SuccessPopup/SignupSuccessPopup.jsx
+++ b/client/src/components/SuccessPopup/SignupSuccessPopup.jsx
@@ -1,28 +1,26 @@
-import "./SuccessPopup.css";
 import { UseUser } from "../../context/UserContext";
 import handleKeyDown from "../../util/handleKeyDown";
+import SuccessPopup from "./SuccessPopup";
 
 export default function SignupSuccessPopup({ goToProfile }) {
   const { user } = UseUser();
   return (
-    <div className="popup-overlay">
-      <div className="popup-card">
-        <h2>Welcome {user?.first_name}</h2>
-        <p>
-          You successfully signed up and logged in! Manage your skill set and
-          address in your profile to get the most relevant jobs.
-        </p>
-        <div className="popup-buttons">
-          <button
-            className="btn-primary"
-            autoFocus
-            onClick={goToProfile}
-            onKeyDown={(e) => handleKeyDown(e, goToProfile)}
-          >
-            Go to Profile
-          </button>
-        </div>
+    <SuccessPopup>
+      <h2>Welcome {user?.first_name}</h2>
+      <p>
+        You successfully signed up and logged in! Manage your skill set and
+        address in your profile to get the most relevant jobs.
+      </p>
+      <div className="popup-buttons">
+        <button
+          className="btn-primary"
+          autoFocus
+          onClick={goToProfile}
+          onKeyDown={(e) => handleKeyDown(e, goToProfile)}
+        >
+          Go to Profile
+        </button>
       </div>
-    </div>
+    </SuccessPopup>
   );
 }

--- a/client/src/components/SuccessPopup/SuccessPopup.jsx
+++ b/client/src/components/SuccessPopup/SuccessPopup.jsx
@@ -1,0 +1,9 @@
+import "./SuccessPopup.css";
+
+export default function SuccessPopup({ children }) {
+  return (
+    <div className="popup-overlay">
+      <div className="popup-card">{children}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
I cleaned up how success / login prompts show up in the app. Before, we had several separate popup components that all drew the same box-on-dark-overlay UI but duplicated the markup. I added one shared SuccessPopup wrapper that handles the layout and styles, and wired the existing popups (login success, signup success, save settings, favorites, apply-to-job) to use it. Copy and look stayed the same; it’s mainly easier to maintain and change later.