### PR TITLE
Improvement design

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,6 +7,7 @@ import "./index.css";
 import MyFavorites from "./pages/MyFavorites/MyFavorites";
 import AuthForms from "./components/AuthForms/AuthForms";
 import About from "./pages/About/About";
+import Privacy from "./pages/Privacy/Privacy";
 import ProtectedRoute from "./components/ProtectedRoute";
 import ResetPasswordForm from "./pages/ResetPassword";
 
@@ -28,6 +29,7 @@ export default function App() {
         <Route path="reset-password" element={<ResetPasswordForm />} />
         <Route path="login" element={<AuthForms />} />
         <Route path="about" element={<About />} />
+        <Route path="privacy" element={<Privacy />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Route>
     </Routes>

--- a/client/src/components/Footer/Footer.css
+++ b/client/src/components/Footer/Footer.css
@@ -1,66 +1,145 @@
-footer {
+.footer {
   margin-top: auto;
-  border-top: 1px solid #e6e6e6;
-  position: relative;
-  transition: border-color 0.2s ease;
-  background-color: #fafafa;
+  border-top: 1px solid #e2e6e9;
+  box-shadow: 0 -1px 0 rgba(44, 44, 44, 0.04);
+  background-color: #fafbfc;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease;
 }
 
-/* Mobile-first: stack on small screens */
 .footer-inner {
+  padding: 1.5rem 1rem;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.25rem;
+  justify-items: center;
   text-align: center;
-  padding: 1.25rem 1rem;
   font-size: 0.875rem;
   z-index: 100;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  align-items: center;
-  justify-content: center;
 }
 
-@media (min-width: 640px) {
+@media (min-width: 768px) {
   .footer-inner {
-    flex-direction: row;
-    justify-content: space-between;
+    grid-template-columns: minmax(0, 1.1fr) auto minmax(0, 1.1fr);
     align-items: center;
-    padding: 1rem 1.25rem;
+    gap: 1.5rem;
+    padding: 1.25rem 1.25rem;
+    min-height: 80px;
     font-size: 0.9rem;
-    min-height: 72px;
+    justify-items: stretch;
+    text-align: left;
+  }
+
+  .footer-brand {
+    text-align: left;
+    justify-self: start;
+  }
+
+  .footer-nav {
+    justify-self: center;
+    justify-content: center;
+  }
+
+  .footer-support {
+    justify-self: end;
+    text-align: right;
   }
 }
 
-.footer-left {
+.footer-brand {
   order: 1;
+}
+
+.footer-brand-title {
+  margin: 0 0 0.25rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #164387;
+  letter-spacing: 0.01em;
 }
 
 .copyright {
   margin: 0;
-  color: #665;
-  font-size: 0.9rem;
-  letter-spacing: 0.02em;
+  color: #6b7280;
+  font-size: 0.8125rem;
+  line-height: 1.5;
 }
 
-.support-footer {
-  display: flex;
-  align-items: center;
+@media (min-width: 768px) {
+  .copyright {
+    font-size: 0.85rem;
+  }
+}
+
+.footer-nav {
+  display: inline-flex;
   flex-wrap: wrap;
-  gap: 0.35rem;
-  font-size: 0.9rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem 0.5rem;
   order: 2;
 }
 
+.footer-nav-divider {
+  color: #d1d5db;
+  user-select: none;
+}
+
+.footer-nav-link {
+  color: #374151;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.875rem;
+  transition: color 0.2s ease;
+}
+
+.footer-nav-link:hover {
+  color: #4a87e1;
+}
+
+.footer-nav-link:focus-visible {
+  outline: 2px solid #164387;
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
+.footer-support {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+  order: 3;
+}
+
+@media (min-width: 768px) {
+  .footer-support {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+  }
+}
+
 .support-label {
-  color: #665;
+  color: #6b7280;
+  font-size: 0.8125rem;
 }
 
 .support-link {
   color: #164387;
   text-decoration: none;
+  font-weight: 500;
+  word-break: break-word;
   transition: color 0.2s ease;
 }
 
 .support-link:hover {
   text-decoration: underline;
   color: #3272d2;
+}
+
+.support-link:focus-visible {
+  outline: 2px solid #164387;
+  outline-offset: 3px;
+  border-radius: 4px;
 }

--- a/client/src/components/Footer/Footer.css
+++ b/client/src/components/Footer/Footer.css
@@ -1,22 +1,24 @@
 .footer {
   margin-top: auto;
+  z-index: 100;
   border-top: 1px solid #e2e6e9;
-  box-shadow: 0 -1px 0 rgba(44, 44, 44, 0.04);
-  background-color: #fafbfc;
-  transition:
-    border-color 0.2s ease,
-    background-color 0.2s ease;
+  box-shadow:
+    0 -1px 3px 0 rgba(44, 44, 44, 0.06),
+    0 -1px 2px -1px rgba(44, 44, 44, 0.04);
+  background-color: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  transition: box-shadow 0.2s ease;
 }
 
 .footer-inner {
-  padding: 1.5rem 1rem;
+  padding: 1.75rem 1rem;
   display: grid;
   grid-template-columns: 1fr;
   gap: 1.25rem;
   justify-items: center;
   text-align: center;
   font-size: 0.875rem;
-  z-index: 100;
 }
 
 @media (min-width: 768px) {
@@ -24,7 +26,7 @@
     grid-template-columns: minmax(0, 1.1fr) auto minmax(0, 1.1fr);
     align-items: center;
     gap: 1.5rem;
-    padding: 1.25rem 1.25rem;
+    padding: 1.5rem 1.25rem;
     min-height: 80px;
     font-size: 0.9rem;
     justify-items: stretch;

--- a/client/src/components/Footer/Footer.css
+++ b/client/src/components/Footer/Footer.css
@@ -87,11 +87,24 @@
 }
 
 .footer-nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   color: #374151;
   text-decoration: none;
   font-weight: 500;
   font-size: 0.875rem;
   transition: color 0.2s ease;
+}
+
+.footer-nav-icon {
+  flex-shrink: 0;
+  color: #6b7280;
+  transition: color 0.2s ease;
+}
+
+.footer-nav-link:hover .footer-nav-icon {
+  color: #4a87e1;
 }
 
 .footer-nav-link:hover {

--- a/client/src/components/Footer/Footer.jsx
+++ b/client/src/components/Footer/Footer.jsx
@@ -1,21 +1,35 @@
+import { Link } from "react-router-dom";
 import "./Footer.css";
+
+const mailSupport =
+  "mailto:jobcompass2025@gmail.com?subject=Question about JobCompass";
 
 export default function Footer() {
   return (
     <footer className="footer">
       <div className="footer-inner content-container">
-        <div className="footer-left">
+        <div className="footer-brand">
+          <p className="footer-brand-title">Job Compass</p>
           <p className="copyright">
-            © {new Date().getFullYear()} JobCompass. All rights reserved.
+            © {new Date().getFullYear()} Job Compass. All rights reserved.
           </p>
         </div>
 
-        <div className="support-footer">
-          <span className="support-label">Support:</span>
-          <a
-            href="mailto:jobcompass2025@gmail.com?subject=Question about JobCompass"
-            className="support-link"
-          >
+        <nav className="footer-nav" aria-label="Footer">
+          <Link className="footer-nav-link" to="/privacy">
+            Privacy
+          </Link>
+          <span className="footer-nav-divider" aria-hidden="true">
+            ·
+          </span>
+          <Link className="footer-nav-link" to="/about#contact">
+            Contact
+          </Link>
+        </nav>
+
+        <div className="footer-support">
+          <span className="support-label">Support</span>
+          <a href={mailSupport} className="support-link">
             jobcompass2025@gmail.com
           </a>
         </div>

--- a/client/src/components/Footer/Footer.jsx
+++ b/client/src/components/Footer/Footer.jsx
@@ -3,7 +3,7 @@ import { Mail, ShieldCheck } from "lucide-react";
 import "./Footer.css";
 
 const mailSupport =
-  "mailto:jobcompass2025@gmail.com?subject=Question about JobCompass";
+  "mailto:jobcompass2025@gmail.com?subject=Question%20about%20JobCompass";
 
 export default function Footer() {
   return (

--- a/client/src/components/Footer/Footer.jsx
+++ b/client/src/components/Footer/Footer.jsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { Mail, ShieldCheck } from "lucide-react";
 import "./Footer.css";
 
 const mailSupport =
@@ -17,12 +18,24 @@ export default function Footer() {
 
         <nav className="footer-nav" aria-label="Footer">
           <Link className="footer-nav-link" to="/privacy">
+            <ShieldCheck
+              className="footer-nav-icon"
+              size={16}
+              strokeWidth={2}
+              aria-hidden
+            />
             Privacy
           </Link>
           <span className="footer-nav-divider" aria-hidden="true">
             ·
           </span>
           <Link className="footer-nav-link" to="/about#contact">
+            <Mail
+              className="footer-nav-icon"
+              size={16}
+              strokeWidth={2}
+              aria-hidden
+            />
             Contact
           </Link>
         </nav>

--- a/client/src/pages/About/About.jsx
+++ b/client/src/pages/About/About.jsx
@@ -210,7 +210,7 @@ export default function About() {
           <p className="contact-text-secondary">
             Drop us a line at{" "}
             <a
-              href="mailto:jobcompass2025@gmail.com?subject=Question about JobCompass"
+              href="mailto:jobcompass2025@gmail.com?subject=Question%20about%20JobCompass"
               className="email-link"
             >
               jobcompass2025@gmail.com

--- a/client/src/pages/About/About.jsx
+++ b/client/src/pages/About/About.jsx
@@ -1,9 +1,20 @@
 import "./About.css";
 
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import { images } from "../../assets";
 import { Filter, Map, Lock, User, Heart, Zap } from "lucide-react";
 
 export default function About() {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (location.hash !== "#contact") return;
+    document.getElementById("contact")?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    });
+  }, [location.pathname, location.hash]);
   const contributors = [
     {
       name: "Yaroslav Kazeev",
@@ -190,7 +201,7 @@ export default function About() {
           ))}
         </div>
 
-        <div className="contact-section">
+        <div className="contact-section" id="contact">
           <h2 className="contact-title">Get in touch?</h2>
           <p className="contact-text-primary">
             Have questions or feedback? We would love to hear from you.

--- a/client/src/pages/Privacy/Privacy.css
+++ b/client/src/pages/Privacy/Privacy.css
@@ -1,0 +1,67 @@
+.privacy-page {
+  padding-bottom: 2rem;
+}
+
+.privacy-main {
+  max-width: 42rem;
+  margin: 0 auto;
+}
+
+.privacy-title {
+  font-size: 1.8rem;
+  font-weight: 600;
+  color: #111827;
+  margin: 2rem 0 1rem;
+  text-align: center;
+}
+
+.privacy-intro {
+  color: #6b7280;
+  font-size: 1rem;
+  line-height: 1.6;
+  margin: 0 0 2rem;
+  text-align: center;
+}
+
+.privacy-block {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1rem;
+  box-shadow:
+    0 1px 3px 0 rgba(0, 0, 0, 0.04),
+    0 0 0 1px rgba(0, 0, 0, 0.02);
+}
+
+.privacy-block h2 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #164387;
+  margin: 0 0 0.5rem;
+}
+
+.privacy-block p {
+  margin: 0;
+  color: #374151;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.privacy-link {
+  color: #4a87e1;
+  font-weight: 600;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.privacy-link:hover {
+  color: #3272d2;
+  text-decoration: underline;
+}
+
+.privacy-link:focus-visible {
+  outline: 2px solid #164387;
+  outline-offset: 2px;
+  border-radius: 2px;
+}

--- a/client/src/pages/Privacy/Privacy.jsx
+++ b/client/src/pages/Privacy/Privacy.jsx
@@ -1,0 +1,58 @@
+import "./Privacy.css";
+
+export default function Privacy() {
+  return (
+    <div className="privacy-page content-container">
+      <main className="privacy-main">
+        <h1 className="privacy-title">Privacy</h1>
+        <p className="privacy-intro">
+          This page describes how Job Compass handles information when you use
+          the app. For questions, reach us via{" "}
+          <a
+            href="mailto:jobcompass2025@gmail.com?subject=Privacy question"
+            className="privacy-link"
+          >
+            jobcompass2025@gmail.com
+          </a>
+          .
+        </p>
+
+        <section className="privacy-block">
+          <h2>What we collect</h2>
+          <p>
+            When you register or update your profile, we store the details you
+            provide (such as email and profile preferences) so the service can
+            work. Usage of the site may produce standard logs on our servers as
+            part of normal operation.
+          </p>
+        </section>
+
+        <section className="privacy-block">
+          <h2>How we use information</h2>
+          <p>
+            We use your data to run Job Compass — authentication, favorites,
+            profile features, and improving reliability. We do not sell your
+            personal information.
+          </p>
+        </section>
+
+        <section className="privacy-block">
+          <h2>Cookies &amp; storage</h2>
+          <p>
+            The app may use browser storage or similar mechanisms to keep you
+            signed in or remember preferences, consistent with how the site is
+            built.
+          </p>
+        </section>
+
+        <section className="privacy-block">
+          <h2>Changes</h2>
+          <p>
+            We may update this summary as the product evolves. Continued use of
+            Job Compass after changes means you accept the updated description.
+          </p>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/client/src/pages/Privacy/Privacy.jsx
+++ b/client/src/pages/Privacy/Privacy.jsx
@@ -9,7 +9,7 @@ export default function Privacy() {
           This page describes how Job Compass handles information when you use
           the app. For questions, reach us via{" "}
           <a
-            href="mailto:jobcompass2025@gmail.com?subject=Privacy question"
+            href="mailto:jobcompass2025@gmail.com?subject=Privacy%20question"
             className="privacy-link"
           >
             jobcompass2025@gmail.com
@@ -30,9 +30,9 @@ export default function Privacy() {
         <section className="privacy-block">
           <h2>How we use information</h2>
           <p>
-            We use your data to run Job Compass — authentication, favorites,
-            profile features, and improving reliability. We do not sell your
-            personal information.
+            We use your data to run Job Compass: authentication, favorites,
+            profile features, and reliability. We do not sell your personal
+            information.
           </p>
         </section>
 


### PR DESCRIPTION
Added a Privacy page at /privacy and registered it in the app router. Updated the footer so it matches the header style and includes Privacy, Contact, branding, copyright, and the support email. Contact now points to the “Get in touch” block on About (/about#contact), which has an anchor and scrolls into view when you open that link.