### PR TITLE
Jobs cleanup

### DIFF
--- a/client/src/context/JobsContext.jsx
+++ b/client/src/context/JobsContext.jsx
@@ -16,7 +16,7 @@ function JobsProvider({ children }) {
   // Clear jobs when user logs in/out
   useEffect(() => {
     setAllJobs([]);
-  }, [user.id]);
+  }, [user?.id]);
 
   // jobs fetch
   const {


### PR DESCRIPTION
We were reading user.id in the jobs reset effect; if user isn’t there yet it can blow up, so we use user?.id instead and still clear the list when the logged-in user changes.