### PR TITLE
Auth cleanup

### DIFF
--- a/server/src/controllers/user.js
+++ b/server/src/controllers/user.js
@@ -4,7 +4,7 @@ import connectNeonDB from "../db/connectNeonDB.js";
 import { v4 as uuidv4 } from "uuid";
 
 import validationErrorMessage from "../util/validationErrorMessage.js";
-import { blacklistedTokens } from "../middleware/authVerify.js";
+import { addTokenToBlacklist } from "../middleware/authVerify.js";
 import validateUserRegistration from "../util/validateUserRegistration.js";
 import updateUserProfile from "./profile.js";
 import uploadImage from "../services/ImageUpload.js";
@@ -200,11 +200,10 @@ export async function loginUser(req, res, next) {
 
 export async function logoutUser(req, res, next) {
   try {
-    // Extract token from "Bearer <token>" header
     const token = req.cookies?.token;
-    if (!token) return next(createHttpError(400, "No token provided")); // Add the token to the in-memory blacklist
+    if (!token) return next(createHttpError(400, "No token provided"));
 
-    blacklistedTokens.push(token);
+    addTokenToBlacklist(token);
     res.clearCookie("token");
 
     res.json({ success: true, msg: "Logged out successfully" });

--- a/server/src/middleware/authVerify.js
+++ b/server/src/middleware/authVerify.js
@@ -25,7 +25,7 @@ function isTokenBlacklisted(token) {
   return true;
 }
 
-/** Requires a valid JWT cookie that has not been logged out */
+/** Requires a valid JWT cookie that has not been logged out*/
 export function verifyToken(req, res, next) {
   try {
     const token = req.cookies?.token;

--- a/server/src/middleware/authVerify.js
+++ b/server/src/middleware/authVerify.js
@@ -2,42 +2,66 @@ import jwt from "jsonwebtoken";
 import { createHttpError } from "./errorHandler.js";
 
 const JWT_SECRET = process.env.JWT_SECRET;
-export const blacklistedTokens = [];
 
-// ========================
-// VERIFY TOKEN - Middleware
-// ========================
+/** token -> blacklistUntilMs (drops automatically once past JWT exp) */
+const tokenBlacklist = new Map();
+
+export function addTokenToBlacklist(token) {
+  const payload = jwt.decode(token);
+  const until =
+    typeof payload?.exp === "number"
+      ? payload.exp * 1000
+      : Date.now() + 7 * 24 * 60 * 60 * 1000;
+  tokenBlacklist.set(token, until);
+}
+
+function isTokenBlacklisted(token) {
+  const until = tokenBlacklist.get(token);
+  if (until === undefined) return false;
+  if (Date.now() >= until) {
+    tokenBlacklist.delete(token);
+    return false;
+  }
+  return true;
+}
+
+/** Requires a valid JWT cookie that has not been logged out */
 export function verifyToken(req, res, next) {
-  let msg;
   try {
     const token = req.cookies?.token;
-
     if (!token) {
-      msg = "No token provided";
-    } else {
-      // Verify the token's signature and expiration time
-      const decoded = jwt.verify(token, JWT_SECRET);
-
-      if (blacklistedTokens.includes(token)) {
-        msg = "Token expired or logged out";
-      } else {
-        // Token is valid, continue to the next middleware/handler
-        req.user = decoded;
-        return next();
-      }
+      return next(createHttpError(401, "No token provided"));
     }
-  } catch (err) {
-    msg = "Invalid or expired token";
+    const decoded = jwt.verify(token, JWT_SECRET);
+    if (isTokenBlacklisted(token)) {
+      return next(createHttpError(401, "Token expired or logged out"));
+    }
+    req.user = decoded;
+    next();
+  } catch {
+    next(createHttpError(401, "Invalid or expired token"));
   }
+}
 
-  const route = req.originalUrl;
-  if (route.startsWith("/api/jobs/search")) {
-    // Job search is accessible to both authenticated and unauthenticated users.
-    // Set req.user to null for unauthenticated requests so downstream code
-    // can explicitly handle guest access.
+/**
+ * Sets req.user when the cookie is valid; otherwise req.user is null (guest).
+ */
+export function attachUserFromCookie(req, res, next) {
+  const token = req.cookies?.token;
+  if (!token) {
     req.user = null;
     return next();
-  } else {
-    return next(createHttpError(401, msg));
+  }
+  try {
+    const decoded = jwt.verify(token, JWT_SECRET);
+    if (isTokenBlacklisted(token)) {
+      req.user = null;
+      return next();
+    }
+    req.user = decoded;
+    next();
+  } catch {
+    req.user = null;
+    next();
   }
 }

--- a/server/src/middleware/authVerify.js
+++ b/server/src/middleware/authVerify.js
@@ -5,13 +5,28 @@ const JWT_SECRET = process.env.JWT_SECRET;
 
 /** token -> blacklistUntilMs (drops automatically once past JWT exp) */
 const tokenBlacklist = new Map();
+const BLACKLIST_SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+
+function pruneExpiredBlacklistedTokens(now = Date.now()) {
+  for (const [token, until] of tokenBlacklist) {
+    if (now >= until) tokenBlacklist.delete(token);
+  }
+}
+
+const blacklistSweep = setInterval(
+  pruneExpiredBlacklistedTokens,
+  BLACKLIST_SWEEP_INTERVAL_MS,
+);
+blacklistSweep.unref?.();
 
 export function addTokenToBlacklist(token) {
   const payload = jwt.decode(token);
+  const now = Date.now();
   const until =
     typeof payload?.exp === "number"
       ? payload.exp * 1000
-      : Date.now() + 7 * 24 * 60 * 60 * 1000;
+      : now + 7 * 24 * 60 * 60 * 1000;
+  if (until <= now) return;
   tokenBlacklist.set(token, until);
 }
 
@@ -25,43 +40,34 @@ function isTokenBlacklisted(token) {
   return true;
 }
 
-/** Requires a valid JWT cookie that has not been logged out*/
-export function verifyToken(req, res, next) {
+/** Returns the decoded payload or null. Does not throw. */
+function decodeAndValidateToken(token) {
+  if (!token) return null;
   try {
-    const token = req.cookies?.token;
-    if (!token) {
-      return next(createHttpError(401, "No token provided"));
-    }
     const decoded = jwt.verify(token, JWT_SECRET);
-    if (isTokenBlacklisted(token)) {
-      return next(createHttpError(401, "Token expired or logged out"));
-    }
-    req.user = decoded;
-    next();
+    if (isTokenBlacklisted(token)) return null;
+    return decoded;
   } catch {
-    next(createHttpError(401, "Invalid or expired token"));
+    return null;
   }
 }
 
-/**
- * Sets req.user when the cookie is valid; otherwise req.user is null (guest).
- */
-export function attachUserFromCookie(req, res, next) {
+export function verifyToken(req, res, next) {
   const token = req.cookies?.token;
-  if (!token) {
-    req.user = null;
-    return next();
+  const decoded = decodeAndValidateToken(token);
+  if (!decoded) {
+    return next(
+      createHttpError(
+        401,
+        token ? "Invalid or expired token" : "No token provided",
+      ),
+    );
   }
-  try {
-    const decoded = jwt.verify(token, JWT_SECRET);
-    if (isTokenBlacklisted(token)) {
-      req.user = null;
-      return next();
-    }
-    req.user = decoded;
-    next();
-  } catch {
-    req.user = null;
-    next();
-  }
+  req.user = decoded;
+  next();
+}
+
+export function attachUserFromCookie(req, res, next) {
+  req.user = decodeAndValidateToken(req.cookies?.token);
+  next();
 }

--- a/server/src/routes/job.js
+++ b/server/src/routes/job.js
@@ -1,9 +1,9 @@
 import express from "express";
 import searchJobs from "../controllers/jobData.js";
-import { verifyToken } from "../middleware/authVerify.js";
+import { attachUserFromCookie } from "../middleware/authVerify.js";
 
 const router = express.Router();
 
-router.post("/search", verifyToken, searchJobs);
+router.post("/search", attachUserFromCookie, searchJobs);
 
 export default router;


### PR DESCRIPTION
Split JWT logic so protected routes require valid login, while `/api/jobs/search` allows guests with `req.user = null` using a separate middleware instead of mixing rules in one place. Replaced the growing blacklist array with a Map that auto-cleans expired tokens after logout or JWT expiry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-out handling so logged-out sessions are reliably blocked by token revocation.
  * Strengthened authentication checks to reject missing, invalid, expired, or revoked tokens with clear 401 responses.
  * Updated job search access logic so guests can search while signed-in users are properly recognized.
  * Revoked tokens now expire from the blacklist automatically over time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->