### PR TITLE
Refactor use fetch hook and consumers #78,92,93,106

### DIFF
--- a/client/src/components/AvatarUploader/AvatarUploader.jsx
+++ b/client/src/components/AvatarUploader/AvatarUploader.jsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from "react";
+import { useRef } from "react";
 import { UseUser } from "../../context/UserContext";
 import "./AvatarUploader.css";
 import useFetch from "../../hooks/useFetch";
@@ -8,7 +8,7 @@ export default function AvatarUploader({ setAlert, delayedClearAlert }) {
   const { user, dispatch } = UseUser();
   const fileInputRef = useRef(null);
 
-  const { isLoading, error, performFetch } = useFetch(
+  const { isLoading, performFetch } = useFetch(
     "/users/update-avatar",
     (result) => {
       dispatch({
@@ -20,15 +20,12 @@ export default function AvatarUploader({ setAlert, delayedClearAlert }) {
       setAlert({ type: "success", message: "Avatar updated!" });
       delayedClearAlert();
     },
-  );
-
-  useEffect(() => {
-    if (error) {
-      console.error("Avatar upload error:", error);
+    (errorMessage) => {
+      console.error("Avatar upload error:", errorMessage);
       setAlert({ type: "error", message: "Failed to upload avatar." });
       delayedClearAlert();
-    }
-  }, [error]);
+    },
+  );
 
   async function handleFileChange(e) {
     const file = e.target.files[0];

--- a/client/src/components/DeleteProfilePopup/DeleteProfilePopup.jsx
+++ b/client/src/components/DeleteProfilePopup/DeleteProfilePopup.jsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { UseUser } from "../../context/UserContext";
 import "./DeleteProfilePopup.css";
 import useFetch from "../../hooks/useFetch";
@@ -8,7 +7,7 @@ import handleKeyDown from "../../util/handleKeyDown";
 export default function DeleteProfilePopup({ setShowDeletePopup }) {
   const { dispatch, setMessage } = UseUser();
 
-  const { isLoading, error, performFetch } = useFetch(
+  const { isLoading, performFetch } = useFetch(
     `/users/delete/`,
     (data) => {
       setMessage(data.msg || "Account deleted successfully!");
@@ -16,15 +15,12 @@ export default function DeleteProfilePopup({ setShowDeletePopup }) {
         dispatch({ type: "LOGOUT" });
       }, 2000);
     },
-  );
-
-  useEffect(() => {
-    if (error) {
-      console.error(error);
+    (errorMessage) => {
+      console.error(errorMessage);
       setMessage("Failed to delete account. Please try again later.");
       setShowDeletePopup(false);
-    }
-  }, [error]);
+    },
+  );
 
   return (
     <div className="profile-popup-overlay">

--- a/client/src/components/SkillsSettings/AIPopup.jsx
+++ b/client/src/components/SkillsSettings/AIPopup.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import useFetch from "../../hooks/useFetch";
 import useAlert from "../../hooks/useAlert";
 import { gif } from "../../assets/index.js";
@@ -13,7 +13,7 @@ export default function AIPopup({ setShowAll, onClose, setAiSkills }) {
   const { alert, setAlert, clearAlert, delayedClearAlert } = useAlert();
   const isCVRef = useRef(true);
 
-  const { isLoading, error, performFetch } = useFetch(
+  const { isLoading, performFetch } = useFetch(
     "/ai/assist-skills",
     (result) => {
       if (
@@ -59,17 +59,14 @@ export default function AIPopup({ setShowAll, onClose, setAiSkills }) {
         setAiSkills([]);
       }
     },
-  );
-
-  useEffect(() => {
-    if (error) {
+    (errorMessage) => {
       setAlert({
         type: "error",
-        message: error?.message || "AI service returned an error.",
+        message: String(errorMessage || "AI service returned an error."),
       });
       delayedClearAlert();
-    }
-  }, [error]);
+    },
+  );
 
   async function handleGetSkills(isCV) {
     clearAlert();

--- a/client/src/components/SkillsSettings/SkillsSettings.jsx
+++ b/client/src/components/SkillsSettings/SkillsSettings.jsx
@@ -1,5 +1,5 @@
 // React imports
-import { useRef, useState, useEffect } from "react";
+import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 // Context, Component imports
 import { UseUser } from "../../context/UserContext";
@@ -31,20 +31,14 @@ export default function SkillsSettings() {
   const handleSkillsResultsRef = useRef(() => {});
   const [aiSkills, setAiSkills] = useState([]);
 
-  const {
-    isLoading,
-    error: fetchError,
-    performFetch,
-  } = useFetch("/users/change-skills", (result) =>
-    handleSkillsResultsRef.current(result),
-  );
-
-  useEffect(() => {
-    if (fetchError) {
-      setAlert({ type: "error", message: String(fetchError) });
+  const { isLoading, performFetch } = useFetch(
+    "/users/change-skills",
+    (result) => handleSkillsResultsRef.current(result),
+    (errorMessage) => {
+      setAlert({ type: "error", message: String(errorMessage) });
       delayedClearAlert();
-    }
-  }, [fetchError]);
+    },
+  );
 
   function prepareSkillsUpdate(
     nextSkills,

--- a/client/src/components/UserMenu.jsx
+++ b/client/src/components/UserMenu.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { NavLink } from "react-router-dom";
 import { icons, gif } from "../assets";
 import { UseUser } from "../context/UserContext";
@@ -10,23 +10,19 @@ export default function UserMenu() {
   const { user, dispatch, isMeLoading, setMessage } = UseUser();
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef(null);
-  const {
-    isLoading: isLogoutLoading,
-    error,
-    performFetch,
-  } = useFetch("/users/logout", (data) => {
-    setMessage(data.msg);
-    dispatch({ type: "LOGOUT" });
-  });
+  const { isLoading: isLogoutLoading, performFetch } = useFetch(
+    "/users/logout",
+    (data) => {
+      setMessage(data.msg);
+      dispatch({ type: "LOGOUT" });
+    },
+    (errorMessage) => {
+      console.error("Error logging out:", errorMessage);
+      setMessage(String(errorMessage));
+    },
+  );
 
   useOutsideClick(menuRef, () => setIsOpen(false));
-
-  useEffect(() => {
-    if (error) {
-      console.error("Error logging out:", error);
-      setMessage(String(error));
-    }
-  }, [error]);
 
   return (
     <div className="user-menu" ref={menuRef}>

--- a/client/src/context/JobsContext.jsx
+++ b/client/src/context/JobsContext.jsx
@@ -11,7 +11,7 @@ function JobsProvider({ children }) {
   const { user } = UseUser();
   const [allJobs, setAllJobs] = useState([]);
   const [searchString, setSearchString] = useState(""); //  global search term
-  const [serverMessage, setServerMessage] = useState("");
+  const [serverMessage, setServerMessage] = useState(null);
 
   // Clear jobs when user logs in/out
   useEffect(() => {
@@ -19,17 +19,19 @@ function JobsProvider({ children }) {
   }, [user.id]);
 
   // jobs fetch
-  const {
-    isLoading: isJobsLoading,
-    error: jobFetchError,
-    performFetch: performJobFetch,
-  } = useFetch("/jobs/search", (data) => {
-    setAllJobs(data.result);
-    if (data.msg) {
-      setServerMessage(data.msg);
-    }
-    fetchBatchTravelDetails(data.result);
-  });
+  const { isLoading: isJobsLoading, performFetch: performJobFetch } = useFetch(
+    "/jobs/search",
+    (data) => {
+      setAllJobs(data.result);
+      if (data.msg) {
+        setServerMessage({ type: "info", message: data.msg });
+      }
+      fetchBatchTravelDetails(data.result);
+    },
+    (errorMessage) => {
+      setServerMessage({ type: "error", message: String(errorMessage) });
+    },
+  );
 
   // travel details fetch
   function getCitiesToFetch(jobsArray) {
@@ -62,11 +64,10 @@ function JobsProvider({ children }) {
     }
   }
 
-  const {
-    isLoading: isTravelLoading,
-    error: travelFetchError,
-    performFetch: performTravelFetch,
-  } = useFetch("/travel/batch", handleTravelFetchResults);
+  const { isLoading: isTravelLoading, performFetch: performTravelFetch } =
+    useFetch("/travel/batch", handleTravelFetchResults, (errorMessage) => {
+      setServerMessage({ type: "error", message: String(errorMessage) });
+    });
 
   async function fetchBatchTravelDetails(jobsArray) {
     const citiesToFetch = getCitiesToFetch(jobsArray);
@@ -93,9 +94,7 @@ function JobsProvider({ children }) {
         allJobs,
         setAllJobs,
         isJobsLoading,
-        jobFetchError,
         isTravelLoading,
-        travelFetchError,
         searchString,
         setSearchString,
         performJobFetch,

--- a/client/src/context/UserContext.jsx
+++ b/client/src/context/UserContext.jsx
@@ -35,24 +35,21 @@ function UserContextProvider({ children }) {
     setMessage(null);
   }
 
-  const {
-    isLoading: isMeLoading,
-    error: fetchMeError,
-    performFetch: performFetchMe,
-  } = useFetch("/users/me", handleFetchMeResults);
+  const { isLoading: isMeLoading, performFetch: performFetchMe } = useFetch(
+    "/users/me",
+    handleFetchMeResults,
+    (errorMessage) => {
+      // "No token provided" is expected when browsing as a guest, so avoid noisy logs.
+      if (errorMessage !== "No token provided") {
+        console.error("Error fetching current user:", errorMessage);
+      }
+      dispatch({ type: "LOGOUT" });
+    },
+  );
 
   useEffect(() => {
     performFetchMe({ credentials: "include" });
   }, []);
-
-  useEffect(() => {
-    if (!fetchMeError) return;
-    // "No token provided" is expected when browsing as a guest, so avoid noisy logs.
-    if (fetchMeError !== "No token provided") {
-      console.error("Error fetching current user:", fetchMeError);
-    }
-    dispatch({ type: "LOGOUT" });
-  }, [fetchMeError]);
 
   return (
     <UserContext.Provider

--- a/client/src/hooks/useFetch.js
+++ b/client/src/hooks/useFetch.js
@@ -62,15 +62,6 @@ export default function useFetch(route, onReceived) {
           console.error("Error parsing JSON response for URL:", url, err);
         }
 
-        if (!res.ok) {
-          setError(
-            (jsonResult && jsonResult.msg) ||
-              `Fetch for ${url} returned an invalid status (${res.status})`,
-          );
-          setIsLoading(false);
-          return;
-        }
-
         if (jsonResult && jsonResult.success === true) {
           onReceived(jsonResult);
         } else {

--- a/client/src/hooks/useFetch.js
+++ b/client/src/hooks/useFetch.js
@@ -62,15 +62,10 @@ export default function useFetch(route, onReceived) {
           console.error("Error parsing JSON response for URL:", url, err);
         }
 
-        if (jsonResult && jsonResult.success === true) {
+        if (jsonResult?.success) {
           onReceived(jsonResult);
         } else {
-          setError(
-            (jsonResult && jsonResult.msg) ||
-              `The result from our backend did not have an error message. Received: ${JSON.stringify(
-                jsonResult,
-              )}`,
-          );
+          setError(jsonResult.msg);
         }
 
         setIsLoading(false);

--- a/client/src/hooks/useFetch.js
+++ b/client/src/hooks/useFetch.js
@@ -24,16 +24,6 @@ export default function useFetch(route, onReceived) {
     controller.abort();
   }
 
-  if (route.includes("api/")) {
-    /**
-     * We add this check here to provide a better error message if you accidentally add the api part
-     * As an error that happens later because of this can be very confusing!
-     */
-    throw Error(
-      "when using the useFetch hook, the route should not include the /api/ part",
-    );
-  }
-
   const [error, setError] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
 

--- a/client/src/hooks/useFetch.js
+++ b/client/src/hooks/useFetch.js
@@ -65,7 +65,7 @@ export default function useFetch(route, onReceived) {
         if (jsonResult?.success) {
           onReceived(jsonResult);
         } else {
-          setError(jsonResult.msg);
+          setError(jsonResult.msg || "The backend returned an error");
         }
 
         setIsLoading(false);

--- a/client/src/hooks/useFetch.js
+++ b/client/src/hooks/useFetch.js
@@ -9,16 +9,13 @@ import { useState } from "react";
  * Our hook will give you an object with the properties:
  *
  * isLoading - true if the fetch is still in progress
- * error - will contain an Error object if something went wrong
  * performFetch - this function will trigger the fetching. It is up to the user of the hook to determine when to do this!
  */
-export default function useFetch(route, onReceived) {
-  const [error, setError] = useState(null);
+export default function useFetch(route, onReceived, onError = () => {}) {
   const [isLoading, setIsLoading] = useState(false);
 
   // Add any args given to the function to the fetch function
   function performFetch(options) {
-    setError(null);
     setIsLoading(true);
 
     const isFormData = options?.body instanceof FormData;
@@ -54,12 +51,12 @@ export default function useFetch(route, onReceived) {
         if (jsonResult?.success) {
           onReceived(jsonResult);
         } else {
-          setError(jsonResult.msg || "The backend returned an error");
+          onError(jsonResult?.msg || "The backend returned an error");
         }
 
         setIsLoading(false);
       } catch (error) {
-        setError(error.message || "An error occurred during fetch");
+        onError(error?.message || "An error occurred during fetch");
         setIsLoading(false);
       }
     }
@@ -67,5 +64,5 @@ export default function useFetch(route, onReceived) {
     fetchData();
   }
 
-  return { isLoading, error, performFetch };
+  return { isLoading, performFetch };
 }

--- a/client/src/hooks/useFetch.js
+++ b/client/src/hooks/useFetch.js
@@ -11,19 +11,8 @@ import { useState } from "react";
  * isLoading - true if the fetch is still in progress
  * error - will contain an Error object if something went wrong
  * performFetch - this function will trigger the fetching. It is up to the user of the hook to determine when to do this!
- * cancelFetch - this function will cancel the fetch, call it when your component is unmounted
  */
 export default function useFetch(route, onReceived) {
-  /**
-   * We use the AbortController which is supported by all modern browsers to handle cancellations
-   * For more info: https://developer.mozilla.org/en-US/docs/Web/API/AbortController
-   */
-  const controller = new AbortController();
-  const signal = controller.signal;
-  function cancelFetch() {
-    controller.abort();
-  }
-
   const [error, setError] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -54,7 +43,7 @@ export default function useFetch(route, onReceived) {
 
       try {
         const url = `/api${route}`;
-        const res = await fetch(url, { ...baseOptions, ...options, signal });
+        const res = await fetch(url, { ...baseOptions, ...options });
         let jsonResult = null;
         try {
           jsonResult = await res.json();
@@ -78,5 +67,5 @@ export default function useFetch(route, onReceived) {
     fetchData();
   }
 
-  return { isLoading, error, performFetch, cancelFetch };
+  return { isLoading, error, performFetch };
 }

--- a/client/src/hooks/useFetch.js
+++ b/client/src/hooks/useFetch.js
@@ -65,23 +65,16 @@ export default function useFetch(route, onReceived) {
       try {
         const url = `/api${route}`;
         const res = await fetch(url, { ...baseOptions, ...options, signal });
-        const contentType = res.headers.get("content-type") || "";
-        const rawText = await res.text();
-        const hasBody = rawText.trim().length > 0;
-
         let jsonResult = null;
-        if (hasBody && contentType.includes("application/json")) {
-          try {
-            jsonResult = JSON.parse(rawText);
-          } catch {
-            console.error("Non-JSON body in response for URL:", url);
-          }
+        try {
+          jsonResult = await res.json();
+        } catch (err) {
+          console.error("Error parsing JSON response for URL:", url, err);
         }
 
         if (!res.ok) {
           setError(
             (jsonResult && jsonResult.msg) ||
-              (hasBody ? rawText : null) ||
               `Fetch for ${url} returned an invalid status (${res.status})`,
           );
           setIsLoading(false);
@@ -94,7 +87,7 @@ export default function useFetch(route, onReceived) {
           setError(
             (jsonResult && jsonResult.msg) ||
               `The result from our backend did not have an error message. Received: ${JSON.stringify(
-                jsonResult ?? rawText,
+                jsonResult,
               )}`,
           );
         }

--- a/client/src/pages/ForgotPassword.jsx
+++ b/client/src/pages/ForgotPassword.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import useFetch from "../hooks/useFetch";
 import useAlert from "../hooks/useAlert";
 import { UseUser } from "../context/UserContext";
@@ -12,20 +12,17 @@ export default function ForgotPasswordForm({ switchToLogin }) {
   const { setMessage } = UseUser();
   const { alert, setAlert, delayedClearAlert } = useAlert();
 
-  const { isLoading, error, performFetch } = useFetch(
+  const { isLoading, performFetch } = useFetch(
     "/users/forgot-password",
     (data) => {
       setSent(true);
       setMessage(data.msg);
     },
-  );
-
-  useEffect(() => {
-    if (error) {
-      setAlert({ type: "error", message: String(error) });
+    (errorMessage) => {
+      setAlert({ type: "error", message: String(errorMessage) });
       delayedClearAlert();
-    }
-  }, [error, setAlert, delayedClearAlert]);
+    },
+  );
 
   async function handleSubmit(e) {
     e.preventDefault(); // Prevent page reload when the form is submitted

--- a/client/src/pages/LoginForm.jsx
+++ b/client/src/pages/LoginForm.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { LogIn, Mail, Eye, EyeOff } from "lucide-react";
 import { UseUser } from "../context/UserContext";
 import AlertMessage from "../components/AlertMessage/AlertMessage";
@@ -36,18 +36,15 @@ export default function LoginForm({
     }
   }
 
-  const { isLoading, error, performFetch } = useFetch(
+  const { isLoading, performFetch } = useFetch(
     "/users/login",
     handleLoginResults,
-  );
-
-  useEffect(() => {
-    if (error) {
-      setAlert({ type: "error", message: String(error) });
+    (errorMessage) => {
+      setAlert({ type: "error", message: String(errorMessage) });
       setLoginSuccessPopup(false);
       setDonationPopup(false);
-    }
-  }, [error]);
+    },
+  );
 
   function handleChange(e) {
     const { name, value } = e.target;

--- a/client/src/pages/Profile/Profile.jsx
+++ b/client/src/pages/Profile/Profile.jsx
@@ -45,7 +45,7 @@ export default function Profile() {
     setConfirmPassword("");
   }, [user]);
 
-  const { error, isLoading, performFetch } = useFetch(
+  const { isLoading, performFetch } = useFetch(
     "/users/profile",
     (data) => {
       dispatch({
@@ -58,12 +58,11 @@ export default function Profile() {
       setAlert({ type: "success", message: "Profile updated successfully!" });
       delayedClearAlert();
     },
+    (errorMessage) => {
+      setAlert({ type: "error", message: String(errorMessage) });
+      delayedClearAlert();
+    },
   );
-
-  useEffect(() => {
-    if (error) setAlert({ type: "error", message: String(error) });
-    delayedClearAlert();
-  }, [error]);
 
   function handleDeleteClick() {
     setShowDeletePopup(true);

--- a/client/src/pages/Profile/Profile.jsx
+++ b/client/src/pages/Profile/Profile.jsx
@@ -182,8 +182,9 @@ export default function Profile() {
       if (cityVal !== user.city) updatedFields.city = cityVal;
       if (countryVal !== user.country) updatedFields.country = countryVal;
       const savedHouseNumber = cleanUpText(String(user.house_number ?? ""));
-      if (house_number !== savedHouseNumber)
+      if (house_number !== savedHouseNumber) {
         updatedFields.house_number = house_number;
+      }
       if (pwdCurrent && pwdNew) {
         updatedFields.currentPassword = pwdCurrent;
         updatedFields.newPassword = pwdNew;

--- a/client/src/pages/ResetPassword.jsx
+++ b/client/src/pages/ResetPassword.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import { Eye, EyeOff } from "lucide-react";
 
@@ -24,19 +24,16 @@ export default function ResetPasswordForm() {
   const [showNewPass, setShowNewPass] = useState(false);
   const [showConfirmPass, setShowConfirmPass] = useState(false);
 
-  const { isLoading, error, performFetch } = useFetch(
+  const { isLoading, performFetch } = useFetch(
     "/users/reset-password",
     () => setResetSuccess(true),
+    (errorMessage) => {
+      setResetSuccess(false);
+      setAlert({ type: "error", message: String(errorMessage) });
+      delayedClearAlert();
+    },
   );
 
-  useEffect(() => {
-    if (error) {
-      const reset = () => setResetSuccess(false);
-      reset();
-      setAlert({ type: "error", message: String(error) });
-      delayedClearAlert();
-    }
-  }, [error, setAlert, delayedClearAlert]);
   async function handleSubmit(e) {
     e.preventDefault();
     if (!token) {

--- a/client/src/pages/SignupForm.jsx
+++ b/client/src/pages/SignupForm.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import useAlert from "../hooks/useAlert";
 import {
   UserPlus,
@@ -60,17 +60,14 @@ export default function SignupForm({ setSignupSuccessPopup, switchToLogin }) {
     setSignupSuccessPopup(true);
   }
 
-  const { isLoading, error, performFetch } = useFetch(
+  const { isLoading, performFetch } = useFetch(
     "/users",
     handleSignupResults,
-  );
-
-  useEffect(() => {
-    if (error) {
-      setAlert({ type: "error", message: String(error) });
+    (errorMessage) => {
+      setAlert({ type: "error", message: String(errorMessage) });
       setSignupSuccessPopup(false);
-    }
-  }, [error]);
+    },
+  );
 
   function handleChange(e) {
     const { name, value } = e.target;

--- a/client/src/pages/openPositions/OpenPositions.jsx
+++ b/client/src/pages/openPositions/OpenPositions.jsx
@@ -36,8 +36,6 @@ export default function OpenPositions() {
     allJobs,
     searchString,
     isJobsLoading,
-    jobFetchError,
-    travelFetchError,
     serverMessage,
     setServerMessage,
   } = UseJobs();
@@ -63,18 +61,15 @@ export default function OpenPositions() {
   ]);
 
   useEffect(() => {
-    if (jobFetchError) {
-      setAlert({ type: "error", message: String(jobFetchError) });
-      delayedClearAlert();
-    } else if (travelFetchError) {
-      setAlert({ type: "error", message: String(travelFetchError) });
-      delayedClearAlert();
-    } else if (serverMessage) {
-      setAlert({ type: "info", message: serverMessage });
-      setServerMessage("");
+    if (serverMessage?.message) {
+      setAlert({
+        type: serverMessage.type || "info",
+        message: serverMessage.message,
+      });
+      setServerMessage(null);
       delayedClearAlert();
     }
-  }, [jobFetchError, travelFetchError, serverMessage, setServerMessage]);
+  }, [serverMessage, setServerMessage]);
 
   const jobsWithSkills = useMemo(() => {
     return allJobs.map((job) => {

--- a/server/src/controllers/user.js
+++ b/server/src/controllers/user.js
@@ -278,7 +278,7 @@ export async function updateUserAvatar(req, res, next) {
       [imageUrl, user_id],
     );
 
-    res.send({
+    res.json({
       success: true,
       message: "Image uploaded successfully.",
       url: imageUrl,

--- a/server/src/util/map_user_details_with_favorites.js
+++ b/server/src/util/map_user_details_with_favorites.js
@@ -47,7 +47,7 @@ export default function mapUserFromJoinRows(
     ...(includeDonation
       ? {
           time_to_donate:
-            userDataRow.number_of_logins + 1 === 5
+            (userDataRow.number_of_logins + 1) % 5 === 0
               ? process.env.DONATION_URL
               : false,
         }

--- a/server/src/util/normalizeEmploymentType.js
+++ b/server/src/util/normalizeEmploymentType.js
@@ -3,12 +3,13 @@ export default function normalizeEmploymentType(typeList) {
   if (Array.isArray(typeList) && typeList.length > 0) {
     const type = typeList[0];
     if (typeof type === "string" && type.length > 0) {
-      if (type === "Intern") {
+      result = (
+        type.charAt(0).toUpperCase() + type.slice(1).toLowerCase()
+      ).replaceAll("_", "-");
+      if (result === "Intern" || result === "Internship") {
         result = "Internship";
-      } else {
-        result = (
-          type.charAt(0).toUpperCase() + type.slice(1).toLowerCase()
-        ).replaceAll("_", "-");
+      } else if (result === "Contract" || result === "Contractor") {
+        result = "Temporary";
       }
     }
   }


### PR DESCRIPTION
PR refactors the fetch hook to eliminate 'double rendering' in React. Before the refactoring, useFetch provided 'error' state to all consumer components, which was used in 'UseEffect' to trigger UI update. Now, a new callback function 'onError' was introduced, which makes this approach consistent with the previous 'onReceive' (happy path) approach.

The cancel fetch functionality was omitted because it is not used, as each fetch can complete and provide information to the User or Job context. It was written for the case where the mounting component triggers a fetch, and then the user cancels it (goes away from the corresponding page). This functionality can be restored if needed in the future.